### PR TITLE
Add option for having a custom snooze value

### DIFF
--- a/src/main/java/com/better/alarm/model/AlarmCore.java
+++ b/src/main/java/com/better/alarm/model/AlarmCore.java
@@ -488,6 +488,9 @@ public final class AlarmCore implements Alarm {
                 Calendar nextTime = Calendar.getInstance();
                 int snoozeMinutes = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(mContext).getString(
                         "snooze_duration", "10"));
+                if(snoozeMinutes == -2) {
+                    snoozeMinutes = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(mContext).getString("custom_snooze_duration", "10"));
+                }
                 nextTime.add(Calendar.MINUTE, snoozeMinutes);
                 return nextTime;
             }

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -79,6 +79,7 @@
         <item>"20 Minuten"</item>
         <item>"25 Minuten"</item>
         <item>"30 Minuten"</item>
+        <item>"Kustom"</item>
     </string-array>
     <string name="alarm_alert_reschedule_text">Neu planen</string>
     <string name="alarm_alert_hold_the_button_text">Halten Sie die Taste!</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -118,6 +118,7 @@
         <item>20 minutos</item>
         <item>25 minutos</item>
         <item>30 minutos</item>
+        <item>Custom</item>
     </string-array>
     <!--
          Values that are retrieved from the ListPreference. These must match
@@ -131,6 +132,7 @@
         <item>20</item>
         <item>25</item>
         <item>30</item>
+        <item>-2</item>
     </string-array>
     <string name="alarm_alert_reschedule_text">Reprogramar</string>
     <string name="alarm_alert_hold_the_button_text">Mantenga pulsado el botón!</string>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -94,6 +94,7 @@
         <item>"20 minuti"</item>
         <item>"25 minuti"</item>
         <item>"30 minuti"</item>
+        <item>"Personalizzato"</item>
     </string-array>
     <string name="alarm_alert_reschedule_text">Ripianificare</string>
     <string name = "alarm_alert_hold_the_button_text">Tenere premuto il tasto!</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -79,6 +79,7 @@
         <item>"20 минут"</item>
         <item>"25 минут"</item>
         <item>"30 минут"</item>
+        <item>"Custom"</item>
     </string-array>
     <string name="alarm_alert_reschedule_text">Перенести</string>
     <string name = "alarm_alert_hold_the_button_text">Удерживайте кнопку!</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
          Entries listed in the ListPreference when invoking the snooze duration
          preference.
     -->
+    <string name="snooze_duration_custom_option_title">Custom snooze value</string>
     <string-array name="snooze_duration_with_off_entries">
         <item>Off</item>
         <item>5 minutes</item>
@@ -118,6 +119,7 @@
         <item>20 minutes</item>
         <item>25 minutes</item>
         <item>30 minutes</item>
+        <item>Custom</item>
     </string-array>
     <!--
          Values that are retrieved from the ListPreference. These must match
@@ -131,6 +133,7 @@
         <item>20</item>
         <item>25</item>
         <item>30</item>
+        <item>-2</item>
     </string-array>
     <string name="alarm_alert_reschedule_text">Reschedule</string>
     <string name="alarm_alert_hold_the_button_text">Hold the button!</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -97,6 +97,14 @@
             android:defaultValue="10"
             android:dialogTitle="@string/snooze_duration_title" />
 
+        <EditTextPreference
+            android:key="custom_snooze_duration"
+            android:title="@string/snooze_duration_custom_option_title"
+            android:summary="Setup a custom snooze (minutes)"
+            android:numeric="integer"
+            android:maxLength="2"
+            />
+
         <ListPreference
             android:key="auto_silence"
             android:title="@string/auto_silence_title"


### PR DESCRIPTION
This change adds a "Custom" option to the snooze time selector, and a preference option to set a custom time in minutes for the snooze time, that will be activated when "Custom" is selected.