### PR TITLE
Can disable fade-in

### DIFF
--- a/src/main/java/com/better/alarm/presenter/SettingsFragment.java
+++ b/src/main/java/com/better/alarm/presenter/SettingsFragment.java
@@ -180,7 +180,11 @@ public class SettingsFragment extends PreferenceFragment {
                         @Override
                         public void accept(@NonNull String newValue) throws Exception {
                             int i = Integer.parseInt(newValue);
-                            fadeInDuration.setSummary(getString(R.string.fade_in_summary, i));
+                            if (i == 1) {
+                                fadeInDuration.setSummary(getString(R.string.fade_in_off_summary));
+                            } else {
+                                fadeInDuration.setSummary(getString(R.string.fade_in_summary, i));
+                            }
                         }
                     });
             dispoables.add(disposable);

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -49,15 +49,16 @@
         <item>120 Sekunden</item>
     </string-array>
     <string name="fade_in_summary">Fade-in Dauer ist <xliff:g id="seconds">%d</xliff:g> Sekunden</string>
-        <string-array name="alarm_set_short">
-    <item msgid="6450913786084215050">"weniger als eine Minute"</item>
-    <item msgid="6002066367368421848">"<xliff:g id="DAYS">%1$s</xliff:g>"</item>
-    <item msgid="8824719306247973774">"<xliff:g id="HOURS">%2$s</xliff:g>"</item>
-    <item msgid="8182406852935468862">"<xliff:g id="DAYS">%1$s</xliff:g> und <xliff:g id="HOURS">%2$s</xliff:g>"</item>
-    <item msgid="2532279224777213194">"<xliff:g id="MINUTES">%3$s</xliff:g>."</item>
-    <item msgid="5936557894247187717">"<xliff:g id="DAYS">%1$s</xliff:g> und <xliff:g id="MINUTES">%3$s</xliff:g>"</item>
-    <item msgid="9115697840826129603">"<xliff:g id="HOURS">%2$s</xliff:g> und <xliff:g id="MINUTES">%3$s</xliff:g>"</item>
-    <item msgid="2332583385137381060">"<xliff:g id="DAYS">%1$s</xliff:g>, <xliff:g id="HOURS">%2$s</xliff:g> und <xliff:g id="MINUTES">%3$s</xliff:g>."</item>
+    <string name="fade_in_off_summary">Fade-in ist aus</string>
+    <string-array name="alarm_set_short">
+        <item msgid="6450913786084215050">"weniger als eine Minute"</item>
+        <item msgid="6002066367368421848">"<xliff:g id="DAYS">%1$s</xliff:g>"</item>
+        <item msgid="8824719306247973774">"<xliff:g id="HOURS">%2$s</xliff:g>"</item>
+        <item msgid="8182406852935468862">"<xliff:g id="DAYS">%1$s</xliff:g> und <xliff:g id="HOURS">%2$s</xliff:g>"</item>
+        <item msgid="2532279224777213194">"<xliff:g id="MINUTES">%3$s</xliff:g>."</item>
+        <item msgid="5936557894247187717">"<xliff:g id="DAYS">%1$s</xliff:g> und <xliff:g id="MINUTES">%3$s</xliff:g>"</item>
+        <item msgid="9115697840826129603">"<xliff:g id="HOURS">%2$s</xliff:g> und <xliff:g id="MINUTES">%3$s</xliff:g>"</item>
+        <item msgid="2332583385137381060">"<xliff:g id="DAYS">%1$s</xliff:g>, <xliff:g id="HOURS">%2$s</xliff:g> und <xliff:g id="MINUTES">%3$s</xliff:g>."</item>
     </string-array>
     <string name="show_info_fragment_title">Zeit bis zum nächsten Alarm</string>
     <string name="show_info_fragment_summary">Zeit bis zum nächsten Alarm unter der Liste der Wecker anzeigen</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -41,6 +41,7 @@
     <string name="longclick_dismiss_summary">Lange drücken, um den Wecker auszuschalten</string>
     <string name="fade_in_time_sec_title">Fade-in Dauer</string>
     <string-array name="fade_in_time_sec_entries">
+        <item>Aus</item>
         <item>10 Sekunden</item>
         <item>20 Sekunden</item>
         <item>30 Sekunden</item>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -18,14 +18,6 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,MissingTranslation,MissingTranslation,MissingTranslation,MissingTranslation,MissingTranslation,MissingTranslation,MissingTranslation,MissingTranslation,MissingTranslation,MissingTranslation">
     <!--      Here come strings which are not contained in the AOSP -->
 
-    <string-array name="fade_in_time_sec_values">
-        <item>1</item>
-        <item>10</item>
-        <item>20</item>
-        <item>30</item>
-        <item>60</item>
-        <item>120</item>
-    </string-array>
     <!-- Setting labels on Set alarm screen: Prealarm -->
     <string name="alarm_prealarm">Pre-alarma discreta</string>
     <!-- Pre-alarm duration title -->
@@ -41,18 +33,6 @@
         <item>30 minutos</item>
         <item>45 minutos</item>
         <item>60 minutos</item>
-    </string-array>
-    <!--
-         Values that are retrieved from the ListPreference. These must match
-         the prealarm_duration_entries above.
-    -->
-    <string-array name="prealarm_duration_values">
-        <item>-1</item>
-        <item>10</item>
-        <item>20</item>
-        <item>30</item>
-        <item>45</item>
-        <item>60</item>
     </string-array>
     <!-- Pre-alarm duration summary string set based on the preference value. -->
     <string name="prealarm_summary">La Pre-alarma comenzará

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -59,6 +59,7 @@
         <item>120 segundos</item>
     </string-array>
     <string name="fade_in_summary">Duración del aumento gradual de volumen es <xliff:g id="seconds">%d</xliff:g> segundos</string>
+    <string name="fade_in_off_summary">Está apagada</string>
     <string-array name="alarm_set_short">
         <item>Menos de un minuto a partir de ahora</item>
         <item><xliff:g id="DAYS" example="2 days">%1$s</xliff:g></item>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -19,6 +19,7 @@
     <!--      Here come strings which are not contained in the AOSP -->
 
     <string-array name="fade_in_time_sec_values">
+        <item>1</item>
         <item>10</item>
         <item>20</item>
         <item>30</item>
@@ -70,6 +71,7 @@
     <string name="longclick_dismiss_summary">Manten el botón descartar presionado para descartar la alarma</string>
     <string name="fade_in_time_sec_title">Duración de aumento gradual de volumen</string>
     <string-array name="fade_in_time_sec_entries">
+        <item>está apagada</item>
         <item>10 segundos</item>
         <item>20 segundos</item>
         <item>30 segundos</item>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -17,6 +17,7 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string-array name="fade_in_time_sec_values">
+        <item>1</item>
         <item>10</item>
         <item>20</item>
         <item>30</item>
@@ -56,6 +57,7 @@
     <string name="longclick_dismiss_summary">Tener premuto il tasto dismiss per far terminare la sveglia</string>
     <string name="fade_in_time_sec_title">Dissolvenza con una maggior durata</string>
     <string-array name="fade_in_time_sec_entries">
+        <item>Off</item>
         <item>10 secondi</item>
         <item>20 secondi</item>
         <item>30 secondi</item>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -16,14 +16,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string-array name="fade_in_time_sec_values">
-        <item>1</item>
-        <item>10</item>
-        <item>20</item>
-        <item>30</item>
-        <item>60</item>
-        <item>120</item>
-    </string-array>
     <!-- Setting labels on Set alarm screen: Prealarm -->
     <string name="alarm_prealarm">Pre-sveglia soft</string>
     <!-- Pre-alarm duration title -->

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -57,6 +57,7 @@
         <item>120 secondi</item>
     </string-array>
     <string name="fade_in_summary">La dissolvenza con maggior durata è <xliff:g id="seconds">%d</xliff:g> secondi</string>
+    <string name="fade_in_off_summary">Off</string>
     <string-array name="alarm_set_short">
         <item>Meno di un minuto da questo istante</item>
         <item><xliff:g id="DAYS" example="2 giorni">%1$s</xliff:g></item>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -49,6 +49,7 @@
         <item>120 секунд</item>
     </string-array>
     <string name="fade_in_summary">Нарастание громкости за <xliff:g id="seconds">%d</xliff:g> секунд</string>
+    <string name="fade_in_off_summary">Выкл</string>
     <string-array name="alarm_set_short">
         <item>"менее чем через минуту"</item>
         <item>"<xliff:g id="DAYS">%1$s</xliff:g>"</item>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -41,6 +41,7 @@
     <string name="longclick_dismiss_summary">Держать кнопку "Отключить" чтобы выключить будильник</string>
     <string name="fade_in_time_sec_title">Нарастание громкости</string>
     <string-array name="fade_in_time_sec_entries">
+        <item>Выкл.</item>
         <item>10 секунд</item>
         <item>20 секунд</item>
         <item>30 секунд</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <!--      Here come strings which are not contained in the AOSP -->
 
     <string-array name="fade_in_time_sec_values" tools:ignore="MissingTranslation">
+        <item>1</item>
         <item>10</item>
         <item>20</item>
         <item>30</item>
@@ -70,6 +71,7 @@
     <string name="longclick_dismiss_summary">Hold the dismiss button to dismiss the alarm</string>
     <string name="fade_in_time_sec_title" tools:ignore="MissingTranslation">Fade-in duration</string>
     <string-array name="fade_in_time_sec_entries">
+        <item>Off</item>
         <item>10 seconds</item>
         <item>20 seconds</item>
         <item>30 seconds</item>
@@ -77,6 +79,7 @@
         <item>120 seconds</item>
     </string-array>
     <string name="fade_in_summary">Fade-in duration is <xliff:g id="seconds">%d</xliff:g> seconds</string>
+    <string name="fade_in_off_summary">Fade-in is switched off</string>
     <string-array name="alarm_set_short">
         <item>Less than a minute from now</item>
         <item><xliff:g id="DAYS" example="2 days">%1$s</xliff:g></item>


### PR DESCRIPTION
Patch for issue #226 
Doesn't totally disable fade-in, but allows setting it to 1 second, which should be close enough.
Also did a bit of cleanup by removing unnecessary translations of integers (which are the same no matter the language, obviously)