### PR TITLE
Separate applicationId for Debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,7 @@ android {
         getByName("debug") {
             isTestCoverageEnabled = true
             buildConfigField("String", "ACRA_EMAIL", "\"$acraEmail\"")
+            applicationIdSuffix = ".debug"
         }
         getByName("release") {
             isMinifyEnabled = false


### PR DESCRIPTION
This allows for simultaneous installations of "Play" and
"Developer" builds.