### PR TITLE
Add buttons to the daysofweek repeat dialog to select/deselect all options

### DIFF
--- a/app/src/main/java/com/better/alarm/view/RepeatPreference.kt
+++ b/app/src/main/java/com/better/alarm/view/RepeatPreference.kt
@@ -51,6 +51,12 @@ fun DaysOfWeek.showDialog(context: Context): Single<DaysOfWeek> {
         .setPositiveButton(android.R.string.ok) { _, _ ->
           emitter.onSuccess(DaysOfWeek(mutableDays))
         }
+        .setNeutralButton("select all") { _, _ ->
+            emitter.onSuccess(DaysOfWeek(0x7f))
+        }
+        .setNegativeButton("deselect all") { _, _ ->
+            emitter.onSuccess(DaysOfWeek(0))
+        }
         .setOnCancelListener { emitter.onSuccess(DaysOfWeek(mutableDays)) }
         .create()
         .show()


### PR DESCRIPTION
I'm not sure if this is an appropriate use of dialog buttons, but having a way of quickly selecting all of the days seems to be very convenient!
When I find myself wanting to make an alarm repeat, it's almost always for every day of the week. Needing to tap 7 checkboxes to achieve this is very cumbersome. It seems to me that selecting only some of the days would be a less common use case, and I'd think it would make more sense to rather prioritize the ease of achieving the "all days" selection.

There might be other ways of achieving this, for example a checkbutton to enable repetition which would then default to all days selected (like aosp deskclock does). But these dialog buttons seemed to be the simplest addition to the current design.
Let me know what you think!