### PR TITLE
AlarmScheduler#queue deleted; Intents now work with ID's.

### DIFF
--- a/app/src/main/java/com/better/alarm/configuration/Container.kt
+++ b/app/src/main/java/com/better/alarm/configuration/Container.kt
@@ -8,6 +8,7 @@ import android.os.PowerManager
 import android.os.Vibrator
 import android.telephony.TelephonyManager
 import android.text.format.DateFormat
+import android.util.Log
 import com.better.alarm.alert.BackgroundNotifications
 import com.better.alarm.background.AlertServicePusher
 import com.better.alarm.background.KlaxonPlugin
@@ -16,6 +17,7 @@ import com.better.alarm.bugreports.BugReporter
 import com.better.alarm.interfaces.IAlarmsManager
 import com.better.alarm.logger.Logger
 import com.better.alarm.logger.LoggerFactory
+import com.better.alarm.logger.StringUtils
 import com.better.alarm.logger.loggerModule
 import com.better.alarm.model.AlarmCore
 import com.better.alarm.model.AlarmSetter
@@ -54,6 +56,7 @@ import org.koin.core.scope.Scope
 import org.koin.dsl.binds
 import org.koin.dsl.module
 
+
 fun Scope.logger(tag: String): Logger {
   return get<LoggerFactory>().createLogger(tag)
 }
@@ -91,10 +94,13 @@ fun startKoin(context: Context): Koin {
     }
 
     factory { get<Context>().getSystemService(Context.ALARM_SERVICE) as AlarmManager }
-    single<AlarmSetter> { AlarmSetter.AlarmSetterImpl(logger("AlarmSetter"), get(), get()) }
+    single<AlarmSetter> { AlarmSetter.AlarmSetterImpl(get(), get()) }
+
     factory { Calendars { Calendar.getInstance() } }
     single<AlarmsScheduler> {
-      AlarmsScheduler(get(), logger("AlarmsScheduler"), get(), get(), get())
+      AlarmsScheduler(get()
+//          , logger("AlarmsScheduler"), get(), get(), get()
+      )
     }
     factory<IAlarmsScheduler> { get<AlarmsScheduler>() }
     single<AlarmCore.IStateNotifier> { AlarmStateNotifier(get()) }

--- a/app/src/main/java/com/better/alarm/configuration/Store.kt
+++ b/app/src/main/java/com/better/alarm/configuration/Store.kt
@@ -43,5 +43,9 @@ data class Store(
     fun alarm(): AlarmValue = alarm
 
     fun millis(): Long = millis
+
+      override fun toString(): String {
+          return "AlarmValue = $alarm, \n millis = $millis"
+      }
   }
 }

--- a/app/src/main/java/com/better/alarm/logger/DateTransformer.java
+++ b/app/src/main/java/com/better/alarm/logger/DateTransformer.java
@@ -1,0 +1,124 @@
+package com.better.alarm.logger;
+
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAccessor;
+
+@RequiresApi(api = Build.VERSION_CODES.O)
+public class DateTransformer {
+    private static final String MONTH_FORMAT = "MMMM";
+    private static final String DATE_FORMAT = "MMMM d, yyyy";
+    private static final String DAY_FORMAT = "EEEE";
+    private static final DateTimeFormatter monthFormat = DateTimeFormatter.ofPattern(MONTH_FORMAT);
+    private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern(DATE_FORMAT);
+    private static final DateTimeFormatter dayFormat = DateTimeFormatter.ofPattern(DAY_FORMAT);
+    private static final DateTimeFormatter timeFormat = DateTimeFormatter.ofPattern("hh:mm a");
+    private static final DateTimeFormatter fullTimeFormat = DateTimeFormatter.ofPattern("MMM dd yyy hh:mm:ss a");
+//    private static final DateTimeFormatter fullTimeFormat = DateTimeFormatter.ofPattern("hh:mm a");
+
+    private static final String separator = "-";
+
+    public static String getDate(long epochDay) {
+        return getOfEpochDay(epochDay).format(dateFormat);
+    }
+
+    private static LocalDate getOfEpochDay(long epochDay) {
+        return LocalDate.ofEpochDay(epochDay);
+    }
+
+    private static final LocalDate firstEpoch = LocalDate.ofEpochDay(0);
+
+    public static long epochMonth(long epochDay){
+        return ChronoUnit.MONTHS.between(firstEpoch, getOfEpochDay(epochDay));
+    }
+
+    public static String ofEpochMonth(long epochMonth){
+        long epochDay = getMonthLocalDate(epochMonth).toEpochDay();
+        return getDate(epochDay);
+    }
+
+    public static LocalDate getMonthLocalDate(long epochMonth) {
+        return firstEpoch.plusMonths(epochMonth).withDayOfMonth(1);
+    }
+
+    public static String getDate(double epochDay) {
+        return getOfEpochDay((long) epochDay).format(dateFormat);
+    }
+
+    public static String getDay(long epochDay) {
+        return getOfEpochDay(epochDay).format(dayFormat);
+    }
+
+    public static String getStringDayOfMonth(long epochDay) {
+        return String.valueOf(getOfEpochDay(epochDay).getDayOfMonth());
+    }
+
+    public static int getDayOfWeek(long epochDay) {
+        return getOfEpochDay(epochDay).getDayOfWeek().getValue();
+    }
+
+//    public static int getMonth(long epochDay) {
+//        return getOfEpochDay(epochDay).getMonthValue();
+//    }
+
+//    public static int getMonthValue(long epochMonth) {
+//        return getMonthLocalDate(epochMonth).getMonthValue();
+////        return getOfEpochDay(epochDay).getMonthValue();
+//    }
+
+    public static String[] getStringYearMonthRange(LocalDate lowerBound, LocalDate upperBound) {
+        long range = ChronoUnit.MONTHS.between(
+                YearMonth.from(lowerBound),
+                YearMonth.from(upperBound)
+        );
+        long lowerEpochDay = lowerBound.toEpochDay();
+        String[] result = new String[(int) range];
+        for (int i = 0; i < range; i++) {
+            result[i] = getStringYearMonth(lowerEpochDay, i);
+        }
+        return result;
+    }
+
+    public static String getStringYearMonth(long epochDay, int monthOffset) {
+        int year = getOfEpochDay(epochDay).plusMonths(monthOffset).getYear();
+        int month = getOfEpochDay(epochDay).plusMonths(monthOffset).getMonthValue();
+        return year + separator + month;
+    }
+
+    public static String getTime(long time) {
+        return Instant.ofEpochMilli(time).atZone(ZoneId.systemDefault()).format(timeFormat);
+    }
+
+    public static String getDateFromTime(long time) {
+        return Instant.ofEpochMilli(time).atZone(ZoneId.systemDefault()).format(fullTimeFormat);
+    }
+
+    public static String ofInstant(Instant time) {
+        return time.atZone(ZoneId.systemDefault()).format(timeFormat);
+    }
+
+    public static String getSecond(long epochSecond) {
+        return Instant.ofEpochSecond(epochSecond).atZone(ZoneId.systemDefault()).format(timeFormat);
+    }
+
+    public static String monthFormat(TemporalAccessor accessor) {
+        return monthFormat.format(accessor);
+    }
+
+    /**returns the passed epochMillis plus a day.*/
+    public static long addADay(long epochMillis) {
+        Instant instant = Instant.ofEpochMilli(epochMillis);
+        instant = instant.plus(1, ChronoUnit.DAYS);
+        return instant.toEpochMilli();
+    }
+
+}
+

--- a/app/src/main/java/com/better/alarm/logger/StringUtils.java
+++ b/app/src/main/java/com/better/alarm/logger/StringUtils.java
@@ -1,0 +1,178 @@
+package com.better.alarm.logger;
+
+
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+public final class StringUtils {
+
+//    public static<Node extends ObservableStringTree2.ObservableStringNode<Node>> ObservableStringTree2<Node> getTree(
+//            Class<Node> constructor,
+//            Supplier<String> delimiterSupplier
+//    ) {
+//        return new ObservableStringTree2<>(
+//                constructor,
+//                delimiterSupplier);
+//    }
+
+    public static String[] split(String original, int index) {
+        return new String[]{
+                original.substring(0, index),
+                original.substring(index)
+        };
+    }
+
+    public static String[] split(String original, int ... points) {
+        int length = points.length + 1;
+        int lastPoint = 0;
+        int lastPos = points.length;
+        String[] result = new String[length];
+        int lastSplittingPoint = points[lastPos - 1];
+        if (!(lastSplittingPoint > original.length())) {
+            for (int i = 0; i < length; i++) {
+
+                if (i != lastPos) {
+                    int currentPoint = points[i];
+                    result[i] = original.substring(lastPoint, currentPoint);
+                    lastPoint = currentPoint;
+                } else {
+                    result[i] = original.substring(lastPoint);
+                }
+            }
+        } else {
+            throw new IndexOutOfBoundsException("Last point: [" + lastSplittingPoint + "] is greater than the length of the original String: " + original +" [" + original.length() + "]. " );
+        }
+        return result;
+    }
+
+    public static String generateRandomHexToken(SecureRandom secureRandom, int byteLength) {
+        byte[] token = new byte[byteLength];
+        secureRandom.nextBytes(token);
+        return new BigInteger(1, token).toString(16); // Hexadecimal encoding
+    }
+
+    public static String intToStringTransformer(int _int, int decimalPlaces, String prefix, String sufix) {
+        String prevString = prefix == null ? "" : prefix;
+        String precString = sufix == null ? "" : sufix;
+        String wholeN = Integer.toString(_int);
+
+        int stringLength = wholeN.length();
+
+        int leftLength = stringLength - decimalPlaces;
+
+        String leftString, rightString, commaString;
+
+        leftString = leftLength < 1 ? "0" : wholeN.substring(0, leftLength);
+
+        rightString = leftLength < 0 ? "0" + wholeN.charAt(0) : wholeN.substring(leftLength,stringLength);
+//        rightString = leftLength < 0 ? "0" + wholeN.substring(0,1) : wholeN.substring(leftLength,stringLength);
+
+        commaString = decimalPlaces == 0 ? "" : ",";
+
+        return prevString + " " + leftString + commaString + rightString + " " + precString;
+    }
+
+    public static String intToStringTransformer(int _int, int decimalPlaces) {
+        String wholeN = Integer.toString(_int);
+
+        int stringLength = wholeN.length();
+
+        int leftLength = stringLength - decimalPlaces;
+
+        String leftString, rightString, commaString;
+
+        leftString = leftLength < 1 ? "0" : wholeN.substring(0, leftLength);
+
+        rightString = leftLength < 0 ? "0" + wholeN.charAt(0) : wholeN.substring(leftLength,stringLength);
+
+        commaString = decimalPlaces == 0 ? "" : ",";
+
+        return leftString + commaString + rightString;
+    }
+
+    public static String[] toStringArray(
+            String fromString
+    ) {
+        if (fromString == null || fromString.length() < 2) {
+            throw new IllegalStateException("Incompatible string: " + fromString);
+        }
+        return fromString.substring(1, fromString.length() - 1).split(", ");
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public static String getStackTrace() {
+        return Arrays.toString(Arrays.stream(Thread.currentThread().getStackTrace()).skip(3).toArray()).replace( ',', '\n' );
+    }
+
+    public static String getSingleStackTrace() {
+        return Thread.currentThread().getStackTrace()[3].toString();
+    }
+
+    /**Includes comma (",") parsing*/
+    public static double parseDouble(String aDouble) {
+        String changed = aDouble;
+        if (aDouble.contains(",")) {
+            changed = aDouble.replace(',','.');
+        }
+        return Double.parseDouble(changed);
+    }
+
+//    /**@param digitPlace = If negative it will be decimals, if positive it will round up to the nearest 10*/
+//    public static String parseDouble(double aDouble, int digitPlace) {
+//        String res = Double.toString(ObjectUtils.round(aDouble, ObjectUtils.scale(1, 10, digitPlace)));
+//        if (digitPlace < 0) {
+//            int indexOfDot = res.indexOf(".");
+//            int cropFrom = Math.min(indexOfDot + Math.abs(digitPlace) + 1, res.length());
+//            return res.substring(0, cropFrom);
+//        }
+//        return res;
+//    }
+
+    private static final String space = "\\s+";
+    public static String[] intoWords(String phrase) {
+        return phrase.split(space);
+    }
+    public static String toPhrase(String... words) {
+        return String.join(space, words);
+    }
+    public static String toPhrase(int start, int end, String ...words) {
+        StringBuilder sb = new StringBuilder();
+        int last = end - 1;
+        assert last < words.length : "End index [" + end + "] greater than words length [" + words.length + "]";
+        for (int i = start; i < last; i++) {
+            sb.append(words[i]);
+            sb.append(space);
+        }
+        sb.append(words[last]);
+        return sb.toString();
+    }
+
+    /**
+     * from A == 0
+     * */
+    public static char from(int alphabetIndex, boolean upperCase) {
+        assert alphabetIndex >= 0 && alphabetIndex <= 25 : "Alphabet index must be between 0 and 25, inclusive.";
+        char c = (char) ('a' + alphabetIndex);
+        if (upperCase) {
+            c -= 32;
+        }
+        return c;
+    }
+
+    public static String hexavigesimal(int number, boolean upperCase) {
+        assert number > 0 : "Only positive numbers, not [" + number + "]";
+        StringBuilder result = new StringBuilder();
+        char base = upperCase ? 'A' : 'a';
+        while (number > 0) {
+            number--;
+            result.insert(0, (char)(base + (number % 26)));
+            number /= 26;
+        }
+        return result.toString();
+    }
+}

--- a/app/src/main/java/com/better/alarm/model/AlarmCore.kt
+++ b/app/src/main/java/com/better/alarm/model/AlarmCore.kt
@@ -17,11 +17,13 @@
 
 package com.better.alarm.model
 
+import android.util.Log
 import com.better.alarm.BuildConfig
 import com.better.alarm.configuration.Prefs
 import com.better.alarm.configuration.Store
 import com.better.alarm.interfaces.Alarm
 import com.better.alarm.interfaces.Intents
+import com.better.alarm.logger.DateTransformer
 import com.better.alarm.logger.Logger
 import com.better.alarm.statemachine.ComplexTransition
 import com.better.alarm.statemachine.State
@@ -33,7 +35,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 sealed class Event {
-  override fun toString(): String = javaClass.simpleName
+    override fun toString(): String = javaClass.simpleName
 }
 
 data class Snooze(val hour: Int?, val minute: Int?) : Event()
@@ -122,729 +124,847 @@ class AlarmCore(
     private val store: Store,
     private val calendars: Calendars,
     private val onDelete: (Int) -> Unit,
-) : Alarm {
-  private val stateMachine: StateMachine<Event>
-  private val df: DateFormat
-  private val container: AlarmValue
-    get() = alarmStore.value
+) : Alarm
+{
+    private val stateMachine: StateMachine<Event>
+    private val df: DateFormat
+    private val container: AlarmValue
+        get() = alarmStore.value
 
-  private val preAlarmDuration: Observable<Int>
-  private val snoozeDuration: Observable<Int>
-  private val autoSilence: Observable<Int>
+    private val preAlarmDuration: Observable<Int>
+    private val snoozeDuration: Observable<Int>
+    private val autoSilence: Observable<Int>
 
-  private val disposable = CompositeDisposable()
+    private val disposable = CompositeDisposable()
 
-  init {
-    this.df = SimpleDateFormat("dd-MM-yy HH:mm:ss", Locale.GERMANY)
-
-    this.preAlarmDuration = prefs.preAlarmDuration.observe()
-    this.snoozeDuration = prefs.snoozeDuration.observe()
-    this.autoSilence = prefs.autoSilence.observe()
-
-    stateMachine = StateMachine("Alarm " + container.id, log)
-
-    preAlarmDuration
-        .skip(1) // not interested in the first update on startup
-        .subscribe { stateMachine.sendEvent(PrealarmDurationChanged) }
-        .let { disposable.add(it) }
-  }
-
-  /** Strategy used to notify other components about alarm state. */
-  interface IStateNotifier {
-    fun broadcastAlarmState(id: Int, action: String, calendar: Calendar? = null)
-    fun broadcastAlarmState(id: Int, action: String)
-  }
-
-  private val disabledState = DisabledState()
-  private val rescheduleTransition = RescheduleTransition()
-  private val enableTransition = EnableTransition()
-  private val enabledState = EnabledState()
-  private val set = enabledState.SetState()
-  private val normalSet = set.NormalSetState()
-  private val preAlarmSet = set.PreAlarmSetState()
-  private val skipping = enabledState.SkippingSetState()
-  private val snoozed = enabledState.SnoozedState()
-  private val preAlarmFired = enabledState.PreAlarmFiredState()
-  private val preAlarmSnoozed = enabledState.PreAlarmSnoozedState()
-  private val fired = enabledState.FiredState()
-  private val deletedState = DeletedState()
-
-  fun start() {
-    stateMachine.start {
-      val root = RootState()
-      addState(root)
-      addState(disabledState, root)
-      addState(enabledState, root)
-      addState(deletedState, root)
-      addState(rescheduleTransition, root)
-      addState(enableTransition, root)
-
-      addState(set, enabledState)
-      addState(preAlarmSet, set)
-      addState(normalSet, set)
-      addState(snoozed, enabledState)
-      addState(skipping, enabledState)
-      addState(preAlarmFired, enabledState)
-      addState(fired, enabledState)
-      addState(preAlarmSnoozed, enabledState)
-
-      val initial = mutableTree.keys.firstOrNull { it.name == alarmStore.value.state }
-      setInitialState(initial ?: disabledState)
+    companion object {
+        private const val TAG = "AlarmCore"
     }
 
-    updateListInStore()
-  }
+    init {
+        this.df = SimpleDateFormat("dd-MM-yy HH:mm:ss", Locale.GERMANY)
 
-  private inner class RootState : AlarmState() {
-    override fun onEvent(event: Event): Boolean {
-      if (BuildConfig.DEBUG) {
-        throw RuntimeException("Unhandled event: $event")
-      } else {
-        log.warning { "Unhandled event: $event" }
-        return true
-      }
-    }
-  }
+        this.preAlarmDuration = prefs.preAlarmDuration.observe()
+        this.snoozeDuration = prefs.snoozeDuration.observe()
+        this.autoSilence = prefs.autoSilence.observe()
 
-  private inner class DeletedState : AlarmState() {
-    override fun onEnter(reason: Event) {
-      removeAlarm()
-      removeFromStore()
-      onDelete(id)
-      alarmStore.delete()
-      disposable.dispose()
-    }
-  }
+        stateMachine = StateMachine("Alarm " + container.id, log)
 
-  private inner class DisabledState : AlarmState() {
-    override fun onEnter(reason: Event) {
-      updateListInStore()
+        preAlarmDuration
+            .skip(1) // not interested in the first update on startup
+            .subscribe { stateMachine.sendEvent(PrealarmDurationChanged) }
+            .let { disposable.add(it) }
     }
 
-    override fun onChange(alarmValue: AlarmValue) {
-      writeChangeData(alarmValue)
-      updateListInStore()
-      if (container.isEnabled) {
-        stateMachine.transitionTo(enableTransition)
-      }
+    /** Strategy used to notify other components about alarm state. */
+    interface IStateNotifier {
+        fun broadcastAlarmState(id: Int, action: String, calendar: Calendar? = null)
+        fun broadcastAlarmState(id: Int, action: String)
     }
 
-    override fun onEnable() {
-      alarmStore.modify { withIsEnabled(true) }
-      stateMachine.transitionTo(enableTransition)
-    }
+    private val disabledState = DisabledState()
+    private val rescheduleTransition = RescheduleTransition()
+    private val enableTransition = EnableTransition()
+    private val enabledState = EnabledState()
+    private val set = enabledState.SetState()
+    private val normalSet = set.NormalSetState()
+    private val preAlarmSet = set.PreAlarmSetState()
+    private val skipping = enabledState.SkippingSetState()
+    private val snoozed = enabledState.SnoozedState()
+    private val preAlarmFired = enabledState.PreAlarmFiredState()
+    private val preAlarmSnoozed = enabledState.PreAlarmSnoozedState()
+    private val fired = enabledState.FiredState()
+    private val deletedState = DeletedState()
 
-    override fun onDelete() {
-      stateMachine.transitionTo(deletedState)
-    }
+    fun start() {
+        stateMachine.start {
+            val root = RootState()
+            addState(root)
+            addState(disabledState, root)
+            addState(enabledState, root)
+            addState(deletedState, root)
+            addState(rescheduleTransition, root)
+            addState(enableTransition, root)
+            addState(set, enabledState)
+            addState(preAlarmSet, set)
+            addState(normalSet, set)
+            addState(snoozed, enabledState)
+            addState(skipping, enabledState)
+            addState(preAlarmFired, enabledState)
+            addState(fired, enabledState)
+            addState(preAlarmSnoozed, enabledState)
 
-    override fun onRefresh() {
-      // NOP
-    }
-
-    override fun onTimeSet() {
-      // NOP
-    }
-
-    override fun onPreAlarmDurationChanged() {
-      // NOP
-    }
-
-    override fun onSnooze(snooze: Snooze) {
-      log.warning { "$this is in DisabledState" }
-    }
-
-    override fun onDismiss() {
-      log.warning { "$this is in DisabledState" }
-    }
-
-    override fun onDisable() {
-      log.warning { "$this is in DisabledState" }
-    }
-  }
-
-  private inner class RescheduleTransition : ComplexTransition<Event>() {
-    override fun performComplexTransition() {
-      if (container.isRepeatSet) {
-        if (container.isPrealarm && preAlarmDuration.blockingFirst() != -1) {
-          stateMachine.transitionTo(preAlarmSet)
-        } else {
-          stateMachine.transitionTo(normalSet)
-        }
-      } else if (container.isDeleteAfterDismiss) {
-        log.debug { "Delete after dismiss!" }
-        stateMachine.transitionTo(deletedState)
-      } else {
-        log.debug { "Repeating is not set, disabling the alarm" }
-        alarmStore.modify { withIsEnabled(false) }
-        stateMachine.transitionTo(disabledState)
-      }
-    }
-  }
-
-  /**
-   * Transition checks if preAlarm for the next alarm is in the future. This is required to prevent
-   * the situation when user sets alarm in time which is less than preAlarm duration. In this case
-   * main alarm should be set.
-   */
-  private inner class EnableTransition : ComplexTransition<Event>() {
-    override fun performComplexTransition() {
-      val preAlarm = calculateNextTime()
-      val preAlarmMinutes = preAlarmDuration.blockingFirst()
-      preAlarm.add(Calendar.MINUTE, -1 * preAlarmMinutes!!)
-      if (container.isPrealarm && preAlarm.after(calendars.now()) && preAlarmMinutes != -1) {
-        stateMachine.transitionTo(preAlarmSet)
-      } else {
-        stateMachine.transitionTo(normalSet)
-      }
-    }
-  }
-
-  /** Master state for all enabled states. Handles disable and delete */
-  private inner class EnabledState : AlarmState() {
-    override fun onEnter(reason: Event) {
-      if (!container.isEnabled) {
-        // if due to an exception during development an alarm is not enabled but the state is
-        alarmStore.modify { withIsEnabled(true) }
-      }
-      updateListInStore()
-    }
-
-    override fun onChange(alarmValue: AlarmValue) {
-      writeChangeData(alarmValue)
-      updateListInStore()
-      if (container.isEnabled) {
-        stateMachine.transitionTo(enableTransition)
-      } else {
-        stateMachine.transitionTo(disabledState)
-      }
-    }
-
-    override fun onDismiss() {
-      stateMachine.transitionTo(rescheduleTransition)
-    }
-
-    override fun onDisable() {
-      alarmStore.modify { withIsEnabled(false) }
-      stateMachine.transitionTo(disabledState)
-    }
-
-    override fun onRefresh() {
-      stateMachine.transitionTo(enableTransition)
-    }
-
-    override fun onTimeSet() {
-      // nothing to do
-    }
-
-    override fun onDelete() {
-      stateMachine.transitionTo(deletedState)
-    }
-
-    inner class SetState : AlarmState() {
-
-      inner class NormalSetState : AlarmState() {
-        override fun onEnter(reason: Event) {
-          broadcastAlarmSetWithNormalTime(calculateNextTime().timeInMillis)
+            val initial = mutableTree.keys.firstOrNull { it.name == alarmStore.value.state }
+            setInitialState(initial ?: disabledState)
         }
 
-        override fun onResume() {
-          val nextTime = calculateNextTime()
-          setAlarm(nextTime, CalendarType.NORMAL)
-          showSkipNotification(nextTime)
-        }
-
-        override fun onFired() {
-          stateMachine.transitionTo(fired)
-        }
-
-        override fun onPreAlarmDurationChanged() {
-          stateMachine.transitionTo(enableTransition)
-        }
-      }
-
-      inner class PreAlarmSetState : AlarmState() {
-        override fun onEnter(reason: Event) {
-          broadcastAlarmSetWithNormalTime(calculateNextPrealarmTime().timeInMillis)
-        }
-
-        override fun onResume() {
-          val nextPrealarmTime = calculateNextPrealarmTime()
-          if (nextPrealarmTime.after(calendars.now())) {
-            setAlarm(nextPrealarmTime, CalendarType.PREALARM)
-            showSkipNotification(nextPrealarmTime)
-          } else {
-            // TODO this should never happen
-            log.e("PreAlarm is still in the past!")
-            stateMachine.transitionTo(if (container.isEnabled) enableTransition else disabledState)
-          }
-        }
-
-        private fun calculateNextPrealarmTime(): Calendar {
-          return calculateNextTime().apply {
-            add(Calendar.MINUTE, -1 * preAlarmDuration.blockingFirst())
-            // since prealarm is before main alarm, it can be already in the
-            // past, so it has to be adjusted.
-            advanceCalendar()
-          }
-        }
-
-        override fun onFired() {
-          stateMachine.transitionTo(preAlarmFired)
-        }
-
-        override fun onPreAlarmDurationChanged() {
-          stateMachine.transitionTo(enableTransition)
-        }
-      }
-
-      private fun showSkipNotification(c: Calendar) {
-        val skipTime = prefs.skipDuration.value
-        val toShowSkip = (c.clone() as Calendar).apply { add(Calendar.MINUTE, -skipTime) }
-        when {
-          skipTime == -1 -> {
-            // switched off
-          }
-          toShowSkip.after(calendars.now()) -> {
-            mAlarmsScheduler.setInexactAlarm(id, toShowSkip)
-          }
-          else -> {
-            log.debug { "Alarm $id is due in less than $skipTime minutes - show notification" }
-            broadcastAlarmState(Intents.ALARM_SHOW_SKIP)
-          }
-        }
-      }
-
-      override fun onEnter(reason: Event) {
         updateListInStore()
-      }
-
-      override fun onInexactFired() {
-        broadcastAlarmState(Intents.ALARM_SHOW_SKIP)
-      }
-
-      override fun onRequestSkip() {
-        when {
-          container.isRepeatSet -> stateMachine.transitionTo(skipping)
-          else -> stateMachine.transitionTo(rescheduleTransition)
-        }
-      }
-
-      override fun exit(reason: Event?) {
-        broadcastAlarmState(Intents.ALARM_REMOVE_SKIP)
-        if (!alarmWillBeRescheduled(reason)) {
-          removeAlarm()
-        }
-        mAlarmsScheduler.removeInexactAlarm(id)
-      }
-
-      override fun onTimeSet() {
-        stateMachine.transitionTo(enableTransition)
-      }
     }
 
-    inner class SkippingSetState : AlarmState() {
-      override fun onEnter(reason: Event) {
-        updateListInStore()
-      }
-
-      override fun onResume() {
-        val nextTime = calculateNextTime()
-        if (nextTime.after(calendars.now())) {
-          mAlarmsScheduler.setInexactAlarm(id, nextTime)
-
-          val nextAfterSkip = calculateNextTime()
-          nextAfterSkip.add(Calendar.DAY_OF_YEAR, 1)
-          val addDays = container.daysOfWeek.getNextAlarm(nextAfterSkip)
-          if (addDays > 0) {
-            nextAfterSkip.add(Calendar.DAY_OF_WEEK, addDays)
-          }
-
-          // this will never (hopefully) fire, but in order to display it everywhere...
-          setAlarm(nextAfterSkip, CalendarType.NORMAL)
-        } else {
-          stateMachine.transitionTo(if (container.isEnabled) enableTransition else disabledState)
-        }
-      }
-
-      override fun onFired() {
-        // yeah should never happen
-        stateMachine.transitionTo(fired)
-      }
-
-      override fun onInexactFired() {
-        stateMachine.transitionTo(enableTransition)
-      }
-
-      override fun exit(reason: Event?) {
-        mAlarmsScheduler.removeInexactAlarm(id)
-        // avoids flicker of the icon
-        if (reason !is RequestSkip) {
-          removeAlarm()
-        }
-      }
-    }
-
-    /** handles both snoozed and main for now */
-    inner class FiredState : AlarmState() {
-      override fun onEnter(reason: Event) {
-        broadcastAlarmState(Intents.ALARM_ALERT_ACTION)
-        val autoSilenceMinutes = autoSilence.blockingFirst()
-        if (autoSilenceMinutes > 0) {
-          // -1 means OFF
-          val nextTime = calendars.now()
-          nextTime.add(Calendar.MINUTE, autoSilenceMinutes)
-          setAlarm(nextTime, CalendarType.AUTOSILENCE)
-        }
-      }
-
-      override fun onFired() {
-        broadcastAlarmState(Intents.ACTION_SOUND_EXPIRED)
-        // this is like a dismiss but we show an additional notification
-        stateMachine.transitionTo(rescheduleTransition)
-      }
-
-      override fun onSnooze(snooze: Snooze) {
-        stateMachine.transitionTo(snoozed)
-      }
-
-      override fun exit(reason: Event?) {
-        broadcastAlarmState(Intents.ALARM_DISMISS_ACTION)
-        removeAlarm()
-      }
-    }
-
-    inner class PreAlarmFiredState : AlarmState() {
-      override fun onEnter(reason: Event) {
-        broadcastAlarmState(Intents.ALARM_PREALARM_ACTION)
-        setAlarm(calculateNextTime(), CalendarType.NORMAL)
-      }
-
-      override fun onFired() {
-        stateMachine.transitionTo(fired)
-      }
-
-      override fun onSnooze(snooze: Snooze) {
-        if (snooze.minute != null) {
-          // snooze to time with prealarm -> go to snoozed
-          stateMachine.transitionTo(snoozed)
-        } else {
-          stateMachine.transitionTo(preAlarmSnoozed)
-        }
-      }
-
-      override fun exit(reason: Event?) {
-        removeAlarm()
-        if (reason !is Fired) {
-          // do not dismiss because we will immediately fire another event at the service
-          broadcastAlarmState(Intents.ALARM_DISMISS_ACTION)
-        }
-      }
-    }
-
-    inner class SnoozedState : AlarmState() {
-      internal var nextTime: Calendar? = null
-
-      private fun nextRegualarSnoozeCalendar(): Calendar {
-        val nextTime = calendars.now()
-        val snoozeMinutes = snoozeDuration.blockingFirst()
-        nextTime.add(Calendar.MINUTE, snoozeMinutes)
-        return nextTime
-      }
-
-      override fun onEnter(reason: Event) {
-        val now = calendars.now()
-        nextTime =
-            when {
-              reason is Snooze && reason.hour != null && reason.minute != null -> {
-                log.debug { "Enter snooze $reason" }
-                val customTime =
-                    calendars.now().apply {
-                      set(Calendar.HOUR_OF_DAY, reason.hour)
-                      set(Calendar.MINUTE, reason.minute)
-                    }
-                when {
-                  customTime.after(now) -> customTime
-                  else -> nextRegualarSnoozeCalendar()
-                }
-              }
-              else -> nextRegualarSnoozeCalendar()
+    private inner class RootState : AlarmState() {
+        override fun onEvent(event: Event): Boolean {
+            if (BuildConfig.DEBUG) {
+                throw RuntimeException("Unhandled event: $event")
+            } else {
+                log.warning { "Unhandled event: $event" }
+                return true
             }
-        // change the next time to show notification properly
-        alarmStore.modify { withNextTime(nextTime) }
-        // updateListInStore()
-        broadcastAlarmState(Intents.ALARM_SNOOZE_ACTION, nextTime) // Yar. 18.08
-      }
+        }
+    }
 
-      override fun onResume() {
-        // alarm was started again while snoozed alarm was hanging in there
-        if (nextTime == null) {
-          nextTime = nextRegualarSnoozeCalendar()
+    private inner class DeletedState : AlarmState() {
+        override fun onEnter(reason: Event) {
+            removeAlarm()
+            removeFromStore()
+            onDelete(id)
+            alarmStore.delete()
+            disposable.dispose()
+        }
+    }
+
+    private inner class DisabledState : AlarmState() {
+        override fun onEnter(reason: Event) {
+            updateListInStore()
         }
 
-        setAlarm(nextTime!!, CalendarType.NORMAL)
-      }
-
-      override fun onFired() {
-        stateMachine.transitionTo(fired)
-      }
-
-      override fun onSnooze(snooze: Snooze) {
-        // reschedule from notification
-        enter(snooze)
-        onResume()
-      }
-
-      override fun exit(reason: Event?) {
-        removeAlarm()
-        broadcastAlarmState(Intents.ACTION_CANCEL_SNOOZE)
-      }
-    }
-
-    inner class PreAlarmSnoozedState : AlarmState() {
-      override fun onEnter(reason: Event) {
-        // Yar 18.08: setAlarm -> resume; setAlarm(calculateNextTime(), CalendarType.NORMAL);
-        broadcastAlarmState(Intents.ALARM_SNOOZE_ACTION, calculateNextTime())
-      }
-
-      override fun onFired() {
-        stateMachine.transitionTo(fired)
-      }
-
-      override fun onSnooze(snooze: Snooze) {
-        // reschedule from notification
-        stateMachine.transitionTo(snoozed)
-      }
-
-      override fun exit(reason: Event?) {
-        removeAlarm()
-        broadcastAlarmState(Intents.ACTION_CANCEL_SNOOZE)
-      }
-
-      override fun onResume() {
-        setAlarm(calculateNextTime(), CalendarType.NORMAL)
-      }
-    }
-  }
-
-  private fun broadcastAlarmState(action: String, calendar: Calendar? = null) {
-    log.trace { "[Alarm ${container.id}] broadcastAlarmState($action)" }
-    when {
-      calendar != null -> broadcaster.broadcastAlarmState(container.id, action, calendar)
-      else -> broadcaster.broadcastAlarmState(container.id, action)
-    }
-    updateListInStore()
-  }
-
-  private fun broadcastAlarmSetWithNormalTime(millis: Long) {
-    store.sets().onNext(Store.AlarmSet(container, millis))
-    updateListInStore()
-  }
-
-  private fun setAlarm(calendar: Calendar, calendarType: CalendarType) {
-    mAlarmsScheduler.setAlarm(container.id, calendarType, calendar, container)
-    alarmStore.modify { withNextTime(calendar) }
-  }
-
-  private fun removeAlarm() {
-    mAlarmsScheduler.removeAlarm(container.id)
-  }
-
-  private fun removeFromStore() {
-    store
-        .alarms()
-        .firstOrError()
-        .subscribe { alarmValues ->
-          val withoutId = removeWithId(alarmValues, container.id)
-          store.alarmsSubject().onNext(withoutId)
+        override fun onChange(alarmValue: AlarmValue) {
+            Log.println(Log.ASSERT, TAG, "onChange: ")
+            writeChangeData(alarmValue)
+            updateListInStore()
+            if (container.isEnabled) {
+                stateMachine.transitionTo(enableTransition)
+            }
         }
-        .let { disposable.add(it) }
-  }
 
-  private fun writeChangeData(data: AlarmValue) {
-    alarmStore.modify { withChangeData(data) }
-  }
-
-  private fun calculateNextTime(): Calendar {
-    val date = container.date
-    return if (date != null) {
-      calendars.now().apply {
-        timeInMillis = date.timeInMillis
-        set(Calendar.HOUR_OF_DAY, container.hour)
-        set(Calendar.MINUTE, container.minutes)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-      }
-    } else {
-      calendars.now().apply {
-        set(Calendar.HOUR_OF_DAY, container.hour)
-        set(Calendar.MINUTE, container.minutes)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-        advanceCalendar()
-      }
-    }
-  }
-
-  private fun Calendar.advanceCalendar() {
-    val now = calendars.now()
-    // if alarm is behind current time, advance one day
-    if (before(now)) {
-      add(Calendar.DAY_OF_YEAR, 1)
-    }
-    val addDays = container.daysOfWeek.getNextAlarm(this)
-    if (addDays > 0) {
-      add(Calendar.DAY_OF_WEEK, addDays)
-    }
-  }
-
-  private fun alarmWillBeRescheduled(reason: Event?): Boolean {
-    return reason is Change && reason.value.isEnabled
-  }
-
-  private abstract inner class AlarmState : State<Event>() {
-    private var handled: Boolean = false
-
-    final override fun enter(reason: Event?) {
-      when (reason) {
-        null -> onResume()
-        else -> {
-          if (this !is EnabledState && this !is ComplexTransition<*>) {
-            alarmStore.modify { withState(name) }
-          }
-          onEnter(reason)
-          onResume()
+        override fun onEnable() {
+            Log.println(Log.ERROR, TAG, "onEnable: ")
+            alarmStore.modify { withIsEnabled(true) }
+            stateMachine.transitionTo(enableTransition)
         }
-      }
-    }
 
-    open fun onEnter(reason: Event) {}
-    open fun onResume() {}
-    override fun exit(reason: Event?) {}
-
-    override fun onEvent(event: Event): Boolean {
-      handled = true
-      when (event) {
-        Create -> Unit
-        is Enable -> onEnable()
-        is Disable -> onDisable()
-        is Snooze -> onSnooze(event)
-        is Dismiss -> onDismiss()
-        is Change -> onChange(event.value)
-        is Fired -> onFired()
-        is PrealarmDurationChanged -> onPreAlarmDurationChanged()
-        is Refresh -> onRefresh()
-        is TimeSet -> onTimeSet()
-        is InexactFired -> onInexactFired()
-        is RequestSkip -> onRequestSkip()
-        is Delete -> onDelete()
-        Create -> {
-          check(!BuildConfig.DEBUG) { "Unexpected $event" }
+        override fun onDelete() {
+            stateMachine.transitionTo(deletedState)
         }
-      }
-      return handled
-    }
 
-    protected fun markNotHandled() {
-      handled = false
-    }
-
-    protected open fun onEnable() = markNotHandled()
-    protected open fun onDisable() = markNotHandled()
-    protected open fun onSnooze(snooze: Snooze) = markNotHandled()
-    protected open fun onDismiss() = markNotHandled()
-    protected open fun onChange(alarmValue: AlarmValue) = markNotHandled()
-    protected open fun onFired() = markNotHandled()
-    protected open fun onInexactFired() = markNotHandled()
-    protected open fun onRequestSkip() = markNotHandled()
-    protected open fun onPreAlarmDurationChanged() = markNotHandled()
-    protected open fun onRefresh() = markNotHandled()
-    protected open fun onTimeSet() = markNotHandled()
-    protected open fun onDelete() = markNotHandled()
-  }
-
-  private fun updateListInStore() {
-    store
-        .alarms()
-        .take(1)
-        .subscribe { alarmValues ->
-          val copy = addOrReplace(alarmValues, container)
-          store.alarmsSubject().onNext(copy)
+        override fun onRefresh() {
+            // NOP
         }
-        .let { disposable.add(it) }
-  }
 
-  fun onAlarmFired() {
-    stateMachine.sendEvent(Fired)
-  }
+        override fun onTimeSet() {
+            // NOP
+        }
 
-  fun onInexactAlarmFired() {
-    stateMachine.sendEvent(InexactFired)
-  }
+        override fun onPreAlarmDurationChanged() {
+            // NOP
+        }
 
-  override fun requestSkip() {
-    stateMachine.sendEvent(RequestSkip)
-  }
+        override fun onSnooze(snooze: Snooze) {
+            log.warning { "$this is in DisabledState" }
+        }
 
-  override fun isSkipping(): Boolean = container.skipping
+        override fun onDismiss() {
+            log.warning { "$this is in DisabledState" }
+        }
 
-  fun refresh() {
-    stateMachine.sendEvent(Refresh)
-  }
+        override fun onDisable() {
+            log.warning { "$this is in DisabledState" }
+        }
+    }
 
-  fun onTimeSet() {
-    stateMachine.sendEvent(TimeSet)
-  }
+    private inner class RescheduleTransition : ComplexTransition<Event>() {
+        override fun performComplexTransition() {
+            if (container.isRepeatSet) {
+                if (container.isPrealarm && preAlarmDuration.blockingFirst() != -1) {
+                    stateMachine.transitionTo(preAlarmSet)
+                } else {
+                    stateMachine.transitionTo(normalSet)
+                }
+            } else if (container.isDeleteAfterDismiss) {
+                log.debug { "Delete after dismiss!" }
+                stateMachine.transitionTo(deletedState)
+            } else {
+                log.debug { "Repeating is not set, disabling the alarm" }
+                alarmStore.modify { withIsEnabled(false) }
+                stateMachine.transitionTo(disabledState)
+            }
+        }
+    }
 
-  fun change(data: AlarmValue) {
-    stateMachine.sendEvent(Change(data))
-  }
+    /**
+     * Transition checks if preAlarm for the next alarm is in the future. This is required to prevent
+     * the situation when user sets alarm in time which is less than preAlarm duration. In this case
+     * main alarm should be set.
+     */
+    private inner class EnableTransition : ComplexTransition<Event>() {
+        override fun performComplexTransition() {
+            val preAlarm = calculateNextTime()
+            val preAlarmMinutes = preAlarmDuration.blockingFirst()
+            preAlarm.add(Calendar.MINUTE, -1 * preAlarmMinutes!!)
+            if (container.isPrealarm && preAlarm.after(calendars.now()) && preAlarmMinutes != -1) {
+                Log.println(Log.VERBOSE, TAG, "performComplexTransition: to preAlarm")
+                stateMachine.transitionTo(preAlarmSet)
+            } else {
+                Log.println(Log.VERBOSE, TAG, "performComplexTransition: to normalSet")
+                stateMachine.transitionTo(normalSet)
+            }
+        }
+    }
 
-  override fun enable(enable: Boolean) {
-    stateMachine.sendEvent(if (enable) Enable else Disable)
-  }
+    /** Master state for all enabled states. Handles disable and delete */
+    private inner class EnabledState : AlarmState() {
+        override fun toString(): String {
+            return super.toString() + "@${hashCode()}"
+        }
+        override fun onEnter(reason: Event) {
+            Log.d(TAG, "onEnter: this = $this")
+            if (!container.isEnabled) {
+                // if due to an exception during development an alarm is not enabled but the state is
+                alarmStore.modify { withIsEnabled(true) } // Writes to DB
+            }
+            updateListInStore()
+        }
 
-  override fun snooze() {
-    stateMachine.sendEvent(Snooze(null, null))
-  }
+        override fun onChange(alarmValue: AlarmValue) {
+            Log.d(TAG, "onChange: this = $this")
+            writeChangeData(alarmValue)
+            updateListInStore()
+            if (container.isEnabled) {
+                stateMachine.transitionTo(enableTransition)
+            } else {
+                stateMachine.transitionTo(disabledState)
+            }
+        }
 
-  override fun snooze(hourOfDay: Int, minute: Int) {
-    stateMachine.sendEvent(Snooze(hourOfDay, minute))
-  }
+        override fun onDismiss() {
+            stateMachine.transitionTo(rescheduleTransition)
+        }
 
-  override fun dismiss() {
-    stateMachine.sendEvent(Dismiss)
-  }
+        override fun onDisable() {
+            alarmStore.modify { withIsEnabled(false) }
+            stateMachine.transitionTo(disabledState)
+        }
 
-  override fun delete() {
-    stateMachine.sendEvent(Delete)
-  }
+        override fun onRefresh() {
+            stateMachine.transitionTo(enableTransition)
+        }
 
-  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++
-  // ++++++ getters for GUI +++++++++++++++++++++++++++++++
-  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        override fun onTimeSet() {
+            // nothing to do
+        }
 
-  override val id: Int
-    get() = container.id
-  override val labelOrDefault: String
-    get() = container.label
-  override val alarmtone: Alarmtone
-    get() = container.alarmtone
+        override fun onDelete() {
+            stateMachine.transitionTo(deletedState)
+        }
 
-  override fun toString(): String {
-    return "AlarmCore ${container.id} $stateMachine on ${df.format(container.nextTime.time)}"
-  }
+        inner class SetState : AlarmState() {
 
-  override fun edit(func: AlarmValue.() -> AlarmValue) {
-    val prev = container
-    change(
-        func(prev).also {
-          require(prev.id == it.id)
-          require(prev.state == it.state)
-          require(prev.nextTime == it.nextTime)
-        })
-  }
+            inner class NormalSetState : AlarmState() {
 
-  override val data: AlarmValue
-    get() = container
+                override fun toString(): String {
+                    return super.toString() + "@${hashCode()}"
+                }
+                override fun onEnter(reason: Event) {
+//            val c = container.date;
+                    val prevTime = getCurrentCalendar().timeInMillis
+                    val myNextTime = DateTransformer.addADay(prevTime)
+                    val nextTimeMillis = calculateNextTime().timeInMillis
+                    Log.println(Log.WARN, TAG, " " +
+                        "\n onEnter: this $this" +
+                        ", \n prevTime = ${DateTransformer.getDateFromTime(prevTime)}" +
+                        ", \n REAL nextTimeMillis = ${DateTransformer.getDateFromTime(nextTimeMillis)}" +
+                        ",\n myNextTime = ${DateTransformer.getDateFromTime(myNextTime)}}"
+                    )
+                    broadcastAlarmSetWithNormalTime(nextTimeMillis)
+                }
+
+                override fun onResume() {
+                    Log.println(Log.ASSERT, TAG, "onResume: this = $this")
+                    val nextTime = calculateNextTime()
+                    setAlarm(nextTime, CalendarType.NORMAL)
+                    showSkipNotification(nextTime)
+                }
+
+                override fun onFired() {
+//            Log.println(Log.ERROR, TAG, " " +
+//                "\n onFired: NORMAL_STATE this = $this" +
+//            ",\n target state = ${stateMachine.targetState}")
+                    stateMachine.transitionTo(fired)
+//            Log.println(Log.WARN, TAG, "onFired: AFTER Transition = ${stateMachine.targetState} ")
+                }
+
+                override fun onPreAlarmDurationChanged() {
+                    stateMachine.transitionTo(enableTransition)
+                }
+            }
+
+            inner class PreAlarmSetState : AlarmState() {
+                override fun onEnter(reason: Event) {
+                    broadcastAlarmSetWithNormalTime(calculateNextPrealarmTime().timeInMillis)
+                }
+
+                override fun onResume() {
+                    val nextPrealarmTime = calculateNextPrealarmTime()
+                    if (nextPrealarmTime.after(calendars.now())) {
+                        setAlarm(nextPrealarmTime, CalendarType.PREALARM)
+                        showSkipNotification(nextPrealarmTime)
+                    } else {
+                        // TODO this should never happen
+                        log.e("PreAlarm is still in the past!")
+                        stateMachine.transitionTo(if (container.isEnabled) enableTransition else disabledState)
+                    }
+                }
+
+                private fun calculateNextPrealarmTime(): Calendar {
+                    return calculateNextTime().apply {
+                        add(Calendar.MINUTE, -1 * preAlarmDuration.blockingFirst())
+                        // since prealarm is before main alarm, it can be already in the
+                        // past, so it has to be adjusted.
+                        advanceCalendar()
+                    }
+                }
+
+                override fun onFired() {
+                    stateMachine.transitionTo(preAlarmFired)
+                }
+
+                override fun onPreAlarmDurationChanged() {
+                    stateMachine.transitionTo(enableTransition)
+                }
+
+                override fun toString(): String {
+                    return super.toString() + "@${hashCode()}"
+                }
+            }
+
+            private fun showSkipNotification(c: Calendar) {
+                val skipTime = prefs.skipDuration.value
+                val toShowSkip = (c.clone() as Calendar).apply { add(Calendar.MINUTE, -skipTime) }
+                when {
+                    skipTime == -1 -> {
+                        // switched off
+                    }
+                    toShowSkip.after(calendars.now()) -> {
+                        mAlarmsScheduler.setInexactAlarm(id, toShowSkip)
+                    }
+                    else -> {
+                        log.debug { "Alarm $id is due in less than $skipTime minutes - show notification" }
+                        broadcastAlarmState(Intents.ALARM_SHOW_SKIP)
+                    }
+                }
+            }
+
+            override fun onEnter(reason: Event) {
+                updateListInStore()
+            }
+
+            override fun onInexactFired() {
+                broadcastAlarmState(Intents.ALARM_SHOW_SKIP)
+            }
+
+            override fun onRequestSkip() {
+                when {
+                    container.isRepeatSet -> stateMachine.transitionTo(skipping)
+                    else -> stateMachine.transitionTo(rescheduleTransition)
+                }
+            }
+
+            override fun toString(): String {
+                return super.toString() +"@${hashCode()}"
+            }
+
+            override fun exit(reason: Event?) {
+                broadcastAlarmState(Intents.ALARM_REMOVE_SKIP)
+                if (!alarmWillBeRescheduled(reason)) {
+                    removeAlarm()
+                }
+                mAlarmsScheduler.removeInexactAlarm(id)
+            }
+
+            override fun onTimeSet() {
+                stateMachine.transitionTo(enableTransition)
+            }
+        }
+
+        inner class SkippingSetState : AlarmState() {
+            override fun onEnter(reason: Event) {
+                updateListInStore()
+            }
+
+            override fun onResume() {
+                val nextTime = calculateNextTime()
+                if (nextTime.after(calendars.now())) {
+                    mAlarmsScheduler.setInexactAlarm(id, nextTime)
+
+                    val nextAfterSkip = calculateNextTime()
+                    nextAfterSkip.add(Calendar.DAY_OF_YEAR, 1)
+                    val addDays = container.daysOfWeek.getNextAlarm(nextAfterSkip)
+                    if (addDays > 0) {
+                        nextAfterSkip.add(Calendar.DAY_OF_WEEK, addDays)
+                    }
+
+                    // this will never (hopefully) fire, but in order to display it everywhere...
+                    setAlarm(nextAfterSkip, CalendarType.NORMAL)
+                } else {
+                    stateMachine.transitionTo(if (container.isEnabled) enableTransition else disabledState)
+                }
+            }
+
+            override fun toString(): String {
+                return super.toString() +"@${hashCode()}"
+            }
+
+            override fun onFired() {
+                // yeah should never happen
+                stateMachine.transitionTo(fired)
+            }
+
+            override fun onInexactFired() {
+                stateMachine.transitionTo(enableTransition)
+            }
+
+            override fun exit(reason: Event?) {
+                mAlarmsScheduler.removeInexactAlarm(id)
+                // avoids flicker of the icon
+                if (reason !is RequestSkip) {
+                    removeAlarm()
+                }
+            }
+        }
+
+        /** handles both snoozed and main for now */
+        inner class FiredState : AlarmState() {
+            override fun toString(): String {
+                return super.toString() + "@${hashCode()}"
+            }
+            override fun onEnter(reason: Event) {
+                broadcastAlarmState(Intents.ALARM_ALERT_ACTION)
+                val autoSilenceMinutes = autoSilence.blockingFirst()
+                if (autoSilenceMinutes > 0) {
+                    // -1 means OFF
+                    val nextTime = calendars.now()
+                    nextTime.add(Calendar.MINUTE, autoSilenceMinutes)
+                    setAlarm(nextTime, CalendarType.AUTOSILENCE)
+                }
+            }
+
+//        override fun onResume() {
+//            Log.println(Log.ASSERT, TAG, "onResume: this = $this" +
+//            ",\n at stack = ${StringUtils.getSingleStackTrace()}")
+//            super.onResume()
+//        }
+
+            override fun onFired() {
+//          Log.println(Log.INFO, TAG, "onFired: this = $this")
+                broadcastAlarmState(Intents.ACTION_SOUND_EXPIRED)
+                // this is like a dismiss but we show an additional notification
+                stateMachine.transitionTo(rescheduleTransition)
+            }
+
+            override fun onSnooze(snooze: Snooze) {
+                stateMachine.transitionTo(snoozed)
+            }
+
+            override fun exit(reason: Event?) {
+                broadcastAlarmState(Intents.ALARM_DISMISS_ACTION)
+                removeAlarm()
+            }
+        }
+
+        inner class PreAlarmFiredState : AlarmState() {
+
+            override fun toString(): String {
+                return super.toString() + "@" + hashCode()
+            }
+
+            override fun onEnter(reason: Event) {
+                broadcastAlarmState(Intents.ALARM_PREALARM_ACTION)
+                setAlarm(calculateNextTime(), CalendarType.NORMAL)
+            }
+
+            override fun onFired() {
+                stateMachine.transitionTo(fired)
+            }
+
+            override fun onSnooze(snooze: Snooze) {
+                if (snooze.minute != null) {
+                    // snooze to time with prealarm -> go to snoozed
+                    stateMachine.transitionTo(snoozed)
+                } else {
+                    stateMachine.transitionTo(preAlarmSnoozed)
+                }
+            }
+
+            override fun exit(reason: Event?) {
+                removeAlarm()
+                if (reason !is Fired) {
+                    // do not dismiss because we will immediately fire another event at the service
+                    broadcastAlarmState(Intents.ALARM_DISMISS_ACTION)
+                }
+            }
+        }
+
+        inner class SnoozedState : AlarmState() {
+            internal var nextTime: Calendar? = null
+
+            private fun nextRegualarSnoozeCalendar(): Calendar {
+                val nextTime = calendars.now()
+                val snoozeMinutes = snoozeDuration.blockingFirst()
+                nextTime.add(Calendar.MINUTE, snoozeMinutes)
+                return nextTime
+            }
+
+            override fun onEnter(reason: Event) {
+                val now = calendars.now()
+                nextTime =
+                    when {
+                        reason is Snooze && reason.hour != null && reason.minute != null -> {
+                            log.debug { "Enter snooze $reason" }
+                            val customTime =
+                                calendars.now().apply {
+                                    set(Calendar.HOUR_OF_DAY, reason.hour)
+                                    set(Calendar.MINUTE, reason.minute)
+                                }
+                            when {
+                                customTime.after(now) -> customTime
+                                else -> nextRegualarSnoozeCalendar()
+                            }
+                        }
+                        else -> nextRegualarSnoozeCalendar()
+                    }
+                // change the next time to show notification properly
+                alarmStore.modify { withNextTime(nextTime) }
+                // updateListInStore()
+                broadcastAlarmState(Intents.ALARM_SNOOZE_ACTION, nextTime) // Yar. 18.08
+            }
+
+            override fun onResume() {
+                // alarm was started again while snoozed alarm was hanging in there
+                if (nextTime == null) {
+                    nextTime = nextRegualarSnoozeCalendar()
+                }
+
+                setAlarm(nextTime!!, CalendarType.NORMAL)
+            }
+
+            override fun onFired() {
+                stateMachine.transitionTo(fired)
+            }
+
+            override fun onSnooze(snooze: Snooze) {
+                // reschedule from notification
+                enter(snooze)
+                onResume()
+            }
+
+            override fun exit(reason: Event?) {
+                removeAlarm()
+                broadcastAlarmState(Intents.ACTION_CANCEL_SNOOZE)
+            }
+        }
+
+        inner class PreAlarmSnoozedState : AlarmState() {
+            override fun onEnter(reason: Event) {
+                // Yar 18.08: setAlarm -> resume; setAlarm(calculateNextTime(), CalendarType.NORMAL);
+                broadcastAlarmState(Intents.ALARM_SNOOZE_ACTION, calculateNextTime())
+            }
+
+            override fun onFired() {
+                stateMachine.transitionTo(fired)
+            }
+
+            override fun onSnooze(snooze: Snooze) {
+                // reschedule from notification
+                stateMachine.transitionTo(snoozed)
+            }
+
+            override fun exit(reason: Event?) {
+                removeAlarm()
+                broadcastAlarmState(Intents.ACTION_CANCEL_SNOOZE)
+            }
+
+            override fun onResume() {
+                setAlarm(calculateNextTime(), CalendarType.NORMAL)
+            }
+        }
+    }
+
+    private fun broadcastAlarmState(action: String, calendar: Calendar? = null) {
+//    log.trace { "[Alarm ${container.id}] broadcastAlarmState($action)" }
+//      Log.d(TAG, "broadcastAlarmState: calendar = $calendar" +
+//      ",\n action = $action")
+        when {
+            calendar != null -> broadcaster.broadcastAlarmState(container.id, action, calendar)
+            else -> broadcaster.broadcastAlarmState(container.id, action)
+        }
+        updateListInStore()
+    }
+
+    private fun broadcastAlarmSetWithNormalTime(millis: Long) {
+        store.sets().onNext(Store.AlarmSet(container, millis))
+        updateListInStore()
+    }
+
+    private fun setAlarm(calendar: Calendar, calendarType: CalendarType) {
+        mAlarmsScheduler.setAlarm(container.id, calendarType, calendar, container)
+        alarmStore.modify { withNextTime(calendar) }
+    }
+
+    private fun removeAlarm() {
+        mAlarmsScheduler.removeAlarm(container.id)
+    }
+
+    private fun removeFromStore() {
+        store
+            .alarms()
+            .firstOrError()
+            .subscribe { alarmValues ->
+                val withoutId = removeWithId(alarmValues, container.id)
+                store.alarmsSubject().onNext(withoutId)
+            }
+            .let { disposable.add(it) }
+    }
+
+    private fun writeChangeData(data: AlarmValue) {
+        alarmStore.modify { withChangeData(data) }
+    }
+
+    private fun calculateNextTime(): Calendar {
+        val date = container.date
+        return if (date != null) {
+            calendars.now().apply {
+                timeInMillis = date.timeInMillis
+                set(Calendar.HOUR_OF_DAY, container.hour)
+                set(Calendar.MINUTE, container.minutes)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+        } else {
+            calendars.now().apply {
+                set(Calendar.HOUR_OF_DAY, container.hour)
+                set(Calendar.MINUTE, container.minutes)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+                Log.d(TAG, "calculateNextTime: prev advanced = ${DateTransformer.getDateFromTime(timeInMillis)}")
+                advanceCalendar()
+                Log.println(Log.INFO, TAG, "calculateNextTime: AFTER advanced = ${DateTransformer.getDateFromTime(timeInMillis)}")
+            }
+        }
+    }
+
+    private fun getCurrentCalendar(): Calendar {
+        val date = container.date
+        return if (date != null) {
+            calendars.now().apply {
+                timeInMillis = date.timeInMillis
+                set(Calendar.HOUR_OF_DAY, container.hour)
+                set(Calendar.MINUTE, container.minutes)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+        } else {
+            calendars.now().apply {
+                set(Calendar.HOUR_OF_DAY, container.hour)
+                set(Calendar.MINUTE, container.minutes)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+//          Log.d(TAG, "calculateNextTime: prev advanced = ${DateTransformer.getDateFromTime(timeInMillis)}")
+//        advanceCalendar()
+//          Log.println(Log.INFO, TAG, "calculateNextTime: AFTER advanced = ${DateTransformer.getDateFromTime(timeInMillis)}")
+            }
+        }
+    }
+
+    private fun Calendar.advanceCalendar() {
+        val now = calendars.now()
+        // if alarm is behind current time, advance one day
+        if (before(now)) {
+            Log.d(TAG, "advanceCalendar: ")
+            add(Calendar.DAY_OF_YEAR, 1)
+        }
+        val addDays = container.daysOfWeek.getNextAlarm(this)
+        Log.println(Log.ERROR, TAG, "advanceCalendar: addDays = $addDays, \n stack = ${StringUtils.getSingleStackTrace()}")
+        if (addDays > 0) {
+            add(Calendar.DAY_OF_WEEK, addDays)
+        }
+    }
+
+//  private fun advanceCalendar1(prev: Calendar) {
+////    val now = calendars.now()
+//    // if alarm is behind current time, advance one day
+//    if (prev.before(calendars.now())) {
+//      prev.add(Calendar.DAY_OF_YEAR, 1)
+//    }
+//    val addDays = container.daysOfWeek.getNextAlarm(this)
+//    if (addDays > 0) {
+//      prev.add(Calendar.DAY_OF_WEEK, addDays)
+//    }
+//  }
+
+    private fun alarmWillBeRescheduled(reason: Event?): Boolean {
+        return reason is Change && reason.value.isEnabled
+    }
+
+    private abstract inner class AlarmState : State<Event>() {
+        private var handled: Boolean = false
+
+        final override fun enter(reason: Event?) {
+//        Log.d(TAG, "enter: reason = $reason" +
+//        ",\n at this $this" +
+//        ",\n at stack = ${StringUtils.getSingleStackTrace()}")
+            when (reason) {
+                null -> onResume()
+                else -> {
+                    if (this !is EnabledState && this !is ComplexTransition<*>) {
+                        alarmStore.modify { withState(name) }
+                    }
+                    onEnter(reason)
+//            Log.println(Log.ERROR, TAG, "enter: this = $this" +
+//            ",\n for event = $reason")
+                    onResume()
+                }
+            }
+        }
+
+        open fun onEnter(reason: Event) {}
+        open fun onResume() {}
+        override fun exit(reason: Event?) {}
+
+        override fun onEvent(event: Event): Boolean {
+            handled = true
+//        Log.println(Log.INFO, TAG, "onEvent: event = $event" +
+//        ",\n at stack ${StringUtils.getSingleStackTrace()}" +
+//        ",\n at this = $this")
+            when (event) {
+                Create -> Unit
+                is Enable -> onEnable()
+                is Disable -> onDisable()
+                is Snooze -> onSnooze(event)
+                is Dismiss -> onDismiss()
+                is Change -> onChange(event.value)
+                is Fired -> {
+//            Log.println(Log.WARN, TAG, "onEvent: FIRED!!!")
+                    onFired()
+                }
+                is PrealarmDurationChanged -> onPreAlarmDurationChanged()
+                is Refresh -> onRefresh()
+                is TimeSet -> onTimeSet()
+                is InexactFired -> onInexactFired()
+                is RequestSkip -> onRequestSkip()
+                is Delete -> onDelete()
+                Create -> check(!BuildConfig.DEBUG) { "Unexpected $event" }
+            }
+//        Log.d(TAG, "onEvent: returning handled = $handled")
+            return handled
+        }
+
+        protected fun markNotHandled() {
+            handled = false
+        }
+
+        protected open fun onEnable() = markNotHandled()
+        protected open fun onDisable() = markNotHandled()
+        protected open fun onSnooze(snooze: Snooze) = markNotHandled()
+        protected open fun onDismiss() = markNotHandled()
+        protected open fun onChange(alarmValue: AlarmValue) = markNotHandled()
+        protected open fun onFired() = markNotHandled()
+        protected open fun onInexactFired() = markNotHandled()
+        protected open fun onRequestSkip() = markNotHandled()
+        protected open fun onPreAlarmDurationChanged() = markNotHandled()
+        protected open fun onRefresh() = markNotHandled()
+        protected open fun onTimeSet() = markNotHandled()
+        protected open fun onDelete() = markNotHandled()
+    }
+
+    private fun updateListInStore() {
+//      Log.println(Log.ASSERT, TAG, "updateListInStore: this = $this" +
+//      ",\n stack = ${StringUtils.getSingleStackTrace()}")
+        store
+            .alarms()
+            .take(1)
+            .subscribe { alarmValues ->
+//            Log.d(TAG, " " +
+//                "\n updateListInStore: alarm values = $alarmValues" +
+//            ",\n this = $this")
+                val copy = addOrReplace(alarmValues, container)
+                store.alarmsSubject().onNext(copy)
+            }
+            .let {
+//            Log.d(TAG, "updateListInStore: it is = $it")
+                disposable.add(it) }
+    }
+
+    fun onAlarmFired() {
+        stateMachine.sendEvent(Fired)
+    }
+
+    fun onInexactAlarmFired() {
+        stateMachine.sendEvent(InexactFired)
+    }
+
+    override fun requestSkip() {
+        stateMachine.sendEvent(RequestSkip)
+    }
+
+    override fun isSkipping(): Boolean = container.skipping
+
+    fun refresh() {
+        stateMachine.sendEvent(Refresh)
+    }
+
+    fun onTimeSet() {
+        stateMachine.sendEvent(TimeSet)
+    }
+
+    fun change(data: AlarmValue) {
+        stateMachine.sendEvent(Change(data))
+    }
+
+    override fun enable(enable: Boolean) {
+        Log.d(TAG, "enable: current node = ${stateMachine.currentState}")
+        stateMachine.sendEvent(if (enable) Enable else Disable)
+    }
+
+    override fun snooze() {
+        stateMachine.sendEvent(Snooze(null, null))
+    }
+
+    override fun snooze(hourOfDay: Int, minute: Int) {
+        stateMachine.sendEvent(Snooze(hourOfDay, minute))
+    }
+
+    override fun dismiss() {
+        stateMachine.sendEvent(Dismiss)
+    }
+
+    override fun delete() {
+        stateMachine.sendEvent(Delete)
+    }
+
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // ++++++ getters for GUI +++++++++++++++++++++++++++++++
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    override val id: Int
+        get() = container.id
+    override val labelOrDefault: String
+        get() = container.label
+    override val alarmtone: Alarmtone
+        get() = container.alarmtone
+
+    override fun toString(): String {
+        return "AlarmCore ${container.id} $stateMachine on ${df.format(container.nextTime.time)}"
+    }
+
+    override fun edit(func: AlarmValue.() -> AlarmValue) {
+        val prev = container
+        change(
+            func(prev).also {
+                require(prev.id == it.id)
+                require(prev.state == it.state)
+                require(prev.nextTime == it.nextTime)
+            })
+    }
+
+    override val data: AlarmValue
+        get() = container
 }

--- a/app/src/main/java/com/better/alarm/model/AlarmCore.kt
+++ b/app/src/main/java/com/better/alarm/model/AlarmCore.kt
@@ -379,7 +379,8 @@ class AlarmCore(
                 }
 
                 override fun onResume() {
-                    Log.println(Log.ASSERT, TAG, "onResume: this = $this")
+                    Log.println(Log.ASSERT, TAG, "onResume: this = $this" +
+                        ", \n stack = ${StringUtils.getSingleStackTrace()}")
                     val nextTime = calculateNextTime()
                     setAlarm(nextTime, CalendarType.NORMAL)
                     showSkipNotification(nextTime)
@@ -706,6 +707,7 @@ class AlarmCore(
     }
 
     private fun setAlarm(calendar: Calendar, calendarType: CalendarType) {
+        Log.println(Log.ERROR, TAG, "setAlarm: nextTime = ${calendar.time}")
         mAlarmsScheduler.setAlarm(container.id, calendarType, calendar, container)
         alarmStore.modify { withNextTime(calendar) }
     }

--- a/app/src/main/java/com/better/alarm/model/AlarmCore.kt
+++ b/app/src/main/java/com/better/alarm/model/AlarmCore.kt
@@ -25,6 +25,7 @@ import com.better.alarm.interfaces.Alarm
 import com.better.alarm.interfaces.Intents
 import com.better.alarm.logger.DateTransformer
 import com.better.alarm.logger.Logger
+import com.better.alarm.logger.StringUtils
 import com.better.alarm.statemachine.ComplexTransition
 import com.better.alarm.statemachine.State
 import com.better.alarm.statemachine.StateMachine

--- a/app/src/main/java/com/better/alarm/model/AlarmSetter.kt
+++ b/app/src/main/java/com/better/alarm/model/AlarmSetter.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import com.better.alarm.logger.Logger
 import com.better.alarm.pendingIntentUpdateCurrentFlag
 import com.better.alarm.presenter.AlarmsListActivity
@@ -50,7 +51,7 @@ interface AlarmSetter {
     }
 
     override fun setUpRTCAlarm(id: Int, typeName: String, calendar: Calendar) {
-      log.debug { "Set $id ($typeName) on ${AlarmsScheduler.DATE_FORMAT.format(calendar.time)}" }
+//      log.debug { "Set $id ($typeName) on ${AlarmsScheduler.DATE_FORMAT.format(calendar.time)}" }
       val pendingAlarm =
           Intent(ACTION_FIRED)
               .apply {
@@ -63,6 +64,7 @@ interface AlarmSetter {
                     mContext, pendingAlarmRequestCode, it, pendingIntentUpdateCurrentFlag())
               }
 
+        Log.println(Log.WARN, TAG, "setUpRTCAlarm: sending intent of id = $id")
       setAlarmStrategy.setRTCAlarm(calendar, pendingAlarm)
     }
 
@@ -73,13 +75,14 @@ interface AlarmSetter {
             putExtra(EXTRA_ID, id)
             putExtra(EXTRA_TYPE, typeName)
           }
+        Log.println(Log.ASSERT, TAG, "fireNow: sending intent of id = $id")
       mContext.sendBroadcast(intent)
     }
 
     override fun setInexactAlarm(id: Int, calendar: Calendar) {
-      log.debug {
-        "setInexactAlarm id: $id on ${AlarmsScheduler.DATE_FORMAT.format(calendar.time)}"
-      }
+//      log.debug {
+//        "setInexactAlarm id: $id on ${AlarmsScheduler.DATE_FORMAT.format(calendar.time)}"
+//      }
       val pendingAlarm =
           Intent(ACTION_INEXACT_FIRED)
               .apply {
@@ -176,6 +179,7 @@ interface AlarmSetter {
   }
 
   companion object {
+      private const val TAG = "AlarmSetter"
     const val ACTION_FIRED = AlarmsScheduler.ACTION_FIRED
     const val ACTION_INEXACT_FIRED = AlarmsScheduler.ACTION_INEXACT_FIRED
     const val EXTRA_ID = AlarmsScheduler.EXTRA_ID

--- a/app/src/main/java/com/better/alarm/model/Alarms.kt
+++ b/app/src/main/java/com/better/alarm/model/Alarms.kt
@@ -74,10 +74,9 @@ class Alarms(
     return alarm
   }
 
-  fun onAlarmFired(alarm: AlarmCore, calendarType: CalendarType?) {
-    // TODO this should not be needed
+  fun onAlarmFired(alarm: AlarmCore) {
     alarmsScheduler.removeAlarm(alarm.id)
-    alarm.onAlarmFired()
+      alarm.onAlarmFired()
   }
 
   override fun enable(alarm: AlarmValue, enable: Boolean) {

--- a/app/src/main/java/com/better/alarm/model/AlarmsReceiver.kt
+++ b/app/src/main/java/com/better/alarm/model/AlarmsReceiver.kt
@@ -18,6 +18,7 @@ package com.better.alarm.model
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.better.alarm.configuration.globalInject
 import com.better.alarm.configuration.globalLogger
 import com.better.alarm.interfaces.PresentationToModelIntents
@@ -25,45 +26,49 @@ import com.better.alarm.logger.Logger
 import kotlinx.coroutines.runBlocking
 
 class AlarmsReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "AlarmsReceiver"
+    }
   private val alarms: Alarms by globalInject()
   private val repository: AlarmsRepository by globalInject()
-  private val log: Logger by globalLogger("AlarmsReceiver")
+//  private val log: Logger by globalLogger("AlarmsReceiver")
 
   override fun onReceive(context: Context, intent: Intent) {
+      Log.println(Log.INFO, TAG, "onReceive: action = ${intent.action}")
     when (intent.action) {
       AlarmsScheduler.ACTION_FIRED -> {
         val id = intent.getIntExtra(AlarmsScheduler.EXTRA_ID, -1)
-        val calendarType =
-            intent.extras?.getString(AlarmsScheduler.EXTRA_TYPE)?.let { CalendarType.valueOf(it) }
-        log.debug { "Fired $id $calendarType" }
-        alarms.getAlarm(id)?.let { alarms.onAlarmFired(it, calendarType) }
+//        val calendarType =
+//            intent.extras?.getString(AlarmsScheduler.EXTRA_TYPE)?.let { CalendarType.valueOf(it) }
+//        log.debug { "Fired $id $calendarType" }
+        alarms.getAlarm(id)?.let { alarms.onAlarmFired(it/*, calendarType*/) }
       }
       AlarmsScheduler.ACTION_INEXACT_FIRED -> {
         val id = intent.getIntExtra(AlarmsScheduler.EXTRA_ID, -1)
-        log.debug { "Fired  ACTION_INEXACT_FIRED $id" }
+//        log.debug { "Fired  ACTION_INEXACT_FIRED $id" }
         alarms.getAlarm(id)?.onInexactAlarmFired()
       }
       Intent.ACTION_BOOT_COMPLETED,
       Intent.ACTION_TIMEZONE_CHANGED,
       Intent.ACTION_LOCALE_CHANGED,
       Intent.ACTION_MY_PACKAGE_REPLACED -> {
-        log.debug { "Refreshing alarms because of ${intent.action}" }
+//        log.debug { "Refreshing alarms because of ${intent.action}" }
         alarms.refresh()
       }
       Intent.ACTION_TIME_CHANGED -> alarms.onTimeSet()
       PresentationToModelIntents.ACTION_REQUEST_SNOOZE -> {
         val id = intent.getIntExtra(AlarmsScheduler.EXTRA_ID, -1)
-        log.debug { "Snooze $id" }
+//        log.debug { "Snooze $id" }
         alarms.getAlarm(id)?.snooze()
       }
       PresentationToModelIntents.ACTION_REQUEST_DISMISS -> {
         val id = intent.getIntExtra(AlarmsScheduler.EXTRA_ID, -1)
-        log.debug { "Dismiss $id" }
+//        log.debug { "Dismiss $id" }
         alarms.getAlarm(id)?.dismiss()
       }
       PresentationToModelIntents.ACTION_REQUEST_SKIP -> {
         val id = intent.getIntExtra(AlarmsScheduler.EXTRA_ID, -1)
-        log.debug { "RequestSkip $id" }
+//        log.debug { "RequestSkip $id" }
         alarms.getAlarm(id)?.requestSkip()
       }
     }

--- a/app/src/main/java/com/better/alarm/model/AlarmsScheduler.kt
+++ b/app/src/main/java/com/better/alarm/model/AlarmsScheduler.kt
@@ -87,22 +87,22 @@ class AlarmsScheduler(
   }
 
   private fun replaceAlarm(id: Int, newAlarm: ScheduledAlarm?) {
-      Log.d(TAG, "replaceAlarm: A = ${collectionToString(queue)}")
+//      Log.d(TAG, "replaceAlarm: A = ${collectionToString(queue)}")
       val prevHead: ScheduledAlarm? = queue.peek()
 
     // remove if we have already an alarm
     queue.removeAll { it.id == id }
-      Log.d(TAG, "replaceAlarm: B = ${collectionToString(queue)}")
+//      Log.d(TAG, "replaceAlarm: B = ${collectionToString(queue)}")
       if (newAlarm != null) {
           queue.add(newAlarm)
       }
 
-      Log.println(Log.VERBOSE, TAG, "replaceAlarm C: is started?? $isStarted" +
-          ",\n queue = ${collectionToString(queue)}")
+//      Log.println(Log.VERBOSE, TAG, "replaceAlarm C: is started?? $isStarted" +
+//          ",\n queue = ${collectionToString(queue)}")
       if (isStarted) {
           fireAlarmsInThePast()
       }
-      Log.d(TAG, "replaceAlarm: D = ${collectionToString(queue)}")
+//      Log.d(TAG, "replaceAlarm: D = ${collectionToString(queue)}")
 
     val currentHead: ScheduledAlarm? = queue.peek()
     when {
@@ -111,14 +111,17 @@ class AlarmsScheduler(
       }
       // no alarms, remove
       currentHead == null -> {
+          Log.d(TAG, "replaceAlarm: removing...")
         setter.removeRTCAlarm()
         notifyListeners()
       }
       // update current RTC, id will be used as the request code
       currentHead != prevHead -> {
 //          if (currentHead != null) {
-              Log.d(TAG, "replaceAlarm: id{${currentHead.id}}" +
-                  ",\n of time = ${currentHead.alarmValue}")
+              Log.d(
+                  TAG, "replaceAlarm (setUpRTCAlarm): id{${currentHead.id}}" +
+                  ",\n of time = ${currentHead.alarmValue}"
+              )
 //          } else {
 //              Log.d(TAG, "replaceAlarm: it was null")
 //          }
@@ -126,7 +129,9 @@ class AlarmsScheduler(
         notifyListeners()
       }
       // if head remains the same, do nothing
-      else -> log.trace { "skip setting $currentHead (already set)" }
+      else -> {
+//          log.trace { "skip setting $currentHead (already set)" }
+      }
     }
   }
 
@@ -180,7 +185,8 @@ class AlarmsScheduler(
   private fun notifyListeners() {
     findNextNormalAlarm()
         ?.let { scheduledAlarm: ScheduledAlarm ->
-          fun findNormalTime(scheduledAlarm: ScheduledAlarm): Long {
+          fun findNormalTime(scheduledAlarm: ScheduledAlarm): Long
+          {
             // we can only assume that the real one will be a little later,
             // namely:
             val prealarmOffsetInMillis = prefs.preAlarmDuration.value * 60 * 1000
@@ -193,7 +199,8 @@ class AlarmsScheduler(
               alarm = scheduledAlarm.alarmValue,
               nextNonPrealarmTime =
                   if (isPrealarm) findNormalTime(scheduledAlarm)
-                  else scheduledAlarm.calendar.timeInMillis)
+                  else scheduledAlarm.calendar.timeInMillis
+          )
         }
         .let { next: Store.Next? -> Optional.fromNullable(next) }
         .run { store.next().onNext(this) }

--- a/app/src/main/java/com/better/alarm/model/AlarmsScheduler.kt
+++ b/app/src/main/java/com/better/alarm/model/AlarmsScheduler.kt
@@ -120,7 +120,8 @@ class AlarmsScheduler(
 //          if (currentHead != null) {
               Log.d(
                   TAG, "replaceAlarm (setUpRTCAlarm): id{${currentHead.id}}" +
-                  ",\n of time = ${currentHead.alarmValue}"
+                  ",\n of time = ${currentHead.alarmValue}" +
+                      ",\n name = ${currentHead.type.name}"
               )
 //          } else {
 //              Log.d(TAG, "replaceAlarm: it was null")

--- a/app/src/main/java/com/better/alarm/model/AlarmsScheduler.kt
+++ b/app/src/main/java/com/better/alarm/model/AlarmsScheduler.kt
@@ -15,208 +15,78 @@
  */
 package com.better.alarm.model
 
-import android.util.Log
 import com.better.alarm.BuildConfig
-import com.better.alarm.configuration.Prefs
-import com.better.alarm.configuration.Store
-import com.better.alarm.logger.Logger
-import com.better.alarm.presenter.AlarmsListActivity
-import com.better.alarm.util.Optional
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
-import java.util.PriorityQueue
 
 class AlarmsScheduler(
     private val setter: AlarmSetter,
-    private val log: Logger,
-    private val store: Store,
-    private val prefs: Prefs,
-    private val calendars: Calendars
 ) : IAlarmsScheduler {
 
-  data class ScheduledAlarm(
-      val id: Int,
-      val calendar: Calendar,
-      val type: CalendarType,
-      val alarmValue: AlarmValue
-  ) : Comparable<ScheduledAlarm> {
+    data class ScheduledAlarm(
+        val id: Int,
+        val calendar: Calendar,
+        val type: CalendarType,
+        val alarmValue: AlarmValue
+    ) : Comparable<ScheduledAlarm> {
 
-    override fun compareTo(other: ScheduledAlarm): Int {
-      return this.calendar.compareTo(other.calendar)
-    }
-
-    override fun toString(): String {
-      return "$id $type on ${DATE_FORMAT.format(calendar.time)}"
-    }
-  }
-
-  private val queue: PriorityQueue<ScheduledAlarm> = PriorityQueue()
-
-  private var isStarted = false
-
-  /** Actually start scheduling alarms */
-  fun start() {
-    isStarted = true
-    fireAlarmsInThePast()
-    if (queue.isNotEmpty()) {
-      // do not use iterator, order is not defined
-      queue.peek()?.let { currentHead ->
-        setter.setUpRTCAlarm(currentHead.id, currentHead.type.name, currentHead.calendar)
-      }
-    }
-      Log.println(Log.ERROR, TAG, "start: queue = ${collectionToString(queue)}")
-      notifyListeners()
-  }
-
-  override fun setAlarm(id: Int, type: CalendarType, calendar: Calendar, alarmValue: AlarmValue) {
-    val scheduledAlarm = ScheduledAlarm(id, calendar, type, alarmValue)
-    replaceAlarm(id, scheduledAlarm)
-  }
-
-  override fun setInexactAlarm(id: Int, cal: Calendar) {
-    setter.setInexactAlarm(id, cal)
-  }
-
-  override fun removeInexactAlarm(id: Int) {
-    setter.removeInexactAlarm(id)
-  }
-
-  override fun removeAlarm(id: Int) {
-    replaceAlarm(id, null)
-  }
-
-  private fun replaceAlarm(id: Int, newAlarm: ScheduledAlarm?) {
-//      Log.d(TAG, "replaceAlarm: A = ${collectionToString(queue)}")
-      val prevHead: ScheduledAlarm? = queue.peek()
-
-    // remove if we have already an alarm
-    queue.removeAll { it.id == id }
-//      Log.d(TAG, "replaceAlarm: B = ${collectionToString(queue)}")
-      if (newAlarm != null) {
-          queue.add(newAlarm)
-      }
-
-//      Log.println(Log.VERBOSE, TAG, "replaceAlarm C: is started?? $isStarted" +
-//          ",\n queue = ${collectionToString(queue)}")
-      if (isStarted) {
-          fireAlarmsInThePast()
-      }
-//      Log.d(TAG, "replaceAlarm: D = ${collectionToString(queue)}")
-
-    val currentHead: ScheduledAlarm? = queue.peek()
-    when {
-      !isStarted -> {
-//        log.trace { "skip setting $currentHead (not started yet)" }
-      }
-      // no alarms, remove
-      currentHead == null -> {
-          Log.d(TAG, "replaceAlarm: removing...")
-        setter.removeRTCAlarm()
-        notifyListeners()
-      }
-      // update current RTC, id will be used as the request code
-      currentHead != prevHead -> {
-//          if (currentHead != null) {
-              Log.d(
-                  TAG, "replaceAlarm (setUpRTCAlarm): id{${currentHead.id}}" +
-                  ",\n of time = ${currentHead.alarmValue}" +
-                      ",\n name = ${currentHead.type.name}"
-              )
-//          } else {
-//              Log.d(TAG, "replaceAlarm: it was null")
-//          }
-        setter.setUpRTCAlarm(currentHead.id, currentHead.type.name, currentHead.calendar)
-        notifyListeners()
-      }
-      // if head remains the same, do nothing
-      else -> {
-//          log.trace { "skip setting $currentHead (already set)" }
-      }
-    }
-  }
-
-  /**
-   * If two alarms were set for the same time,
-   * then the second alarm will be processed in the past.
-   * In this case we remove it from the queue and fire it.
-   */
-  private fun fireAlarmsInThePast() {
-    val now = calendars.now()
-      val peeked : ScheduledAlarm? = queue.peek()
-      val topIsBeforeNow = peeked?.calendar?.before(now)
-//      val topIsBeforeNow = queue.peek()?.calendar?.before(now)
-//      Log.println(Log.ASSERT, TAG, "fireAlarmsInThePast: peeked = $peeked" +
-//          ",\n is before now? $topIsBeforeNow" +
-//          ",\n now = ${now.time}" +
-//          ",\n all in queue = ${collectionToString(queue)}"
-//      )
-    while (!queue.isEmpty() && topIsBeforeNow == true) {
-      // remove happens in fire
-      queue.poll()?.let { firedInThePastAlarm ->
-          Log.println(Log.INFO, TAG, "fireAlarmsInThePast: id{$firedInThePastAlarm.id}" +
-              ",\n for time = ${firedInThePastAlarm.alarmValue}")
-          //Todo: BUG
-        setter.fireNow(firedInThePastAlarm.id, firedInThePastAlarm.type.name)
-      }
-    }
-  }
-
-    fun<V> collectionToString(col: Collection<V>, map: (V) -> String) : String {
-        val b = StringBuilder()
-        for ((i, v) in col.withIndex()) {
-            b.append(
-                " " +
-                    "\n Entry >>>>> No [$i]" +
-                    "\n    item = ${map(v)}"
-            )
+        override fun compareTo(other: ScheduledAlarm): Int {
+            return this.calendar.compareTo(other.calendar)
         }
-        return b.toString()
-    }
-    fun<V> collectionToString(col: Collection<V>) : String {
-        return collectionToString(col, map = {v ->  v.toString()})
-    }
 
-  /**
-   * TODO the whole mechanism has to be revised. Currently we can only know when next alarm is
-   * scheduled and we do not know what is the reason for that. Maybe create a separate component for
-   * that or notify from the alarm SM. Actually notify this component from SM :-) and he can notify
-   * the rest.
-   */
-  private fun notifyListeners() {
-    findNextNormalAlarm()
-        ?.let { scheduledAlarm: ScheduledAlarm ->
-          fun findNormalTime(scheduledAlarm: ScheduledAlarm): Long
-          {
-            // we can only assume that the real one will be a little later,
-            // namely:
-            val prealarmOffsetInMillis = prefs.preAlarmDuration.value * 60 * 1000
-            return scheduledAlarm.calendar.timeInMillis + prealarmOffsetInMillis
-          }
-
-          val isPrealarm = scheduledAlarm.type == CalendarType.PREALARM
-          Store.Next(
-              isPrealarm = isPrealarm,
-              alarm = scheduledAlarm.alarmValue,
-              nextNonPrealarmTime =
-                  if (isPrealarm) findNormalTime(scheduledAlarm)
-                  else scheduledAlarm.calendar.timeInMillis
-          )
+        override fun toString(): String {
+            return "$id " +
+                "on ${DATE_FORMAT.format(calendar.time)}"
         }
-        .let { next: Store.Next? -> Optional.fromNullable(next) }
-        .run { store.next().onNext(this) }
-  }
+    }
 
-  private fun findNextNormalAlarm(): ScheduledAlarm? {
-    return queue.sorted().firstOrNull { it.type != CalendarType.AUTOSILENCE }
-  }
+    private var isStarted = false
+
+    /** Actually start scheduling alarms */
+    fun start() {
+        isStarted = true
+    }
+
+    override fun setAlarm(id: Int, type: CalendarType, calendar: Calendar, alarmValue: AlarmValue) {
+        val scheduledAlarm = ScheduledAlarm(id, calendar, type, alarmValue)
+        replaceAlarm(id, scheduledAlarm)
+    }
+
+    override fun setInexactAlarm(id: Int, cal: Calendar) {
+        setter.setInexactAlarm(id, cal)
+    }
+
+    override fun removeInexactAlarm(id: Int) {
+        setter.removeInexactAlarm(id)
+    }
+
+    override fun removeAlarm(id: Int) {
+        replaceAlarm(id, null)
+    }
+
+    private fun replaceAlarm(id: Int, newAlarm: ScheduledAlarm?) {
+        when
+        {
+            !isStarted -> {
+            }
+            // no alarms, remove
+            newAlarm == null -> {
+                setter.removeRTCAlarm(id)
+            }
+            // update current RTC, id will be used as the request code
+            // if head remains the same, do nothing
+            else -> {
+                setter.setUpRTCAlarm(newAlarm.id, newAlarm.calendar)
+
+            }
+        }
+    }
 
   companion object {
-      private const val TAG = "AlarmsScheduler"
       val DATE_FORMAT: SimpleDateFormat = SimpleDateFormat("dd-MM-yy HH:mm:ss", Locale.GERMANY)
     const val ACTION_FIRED = BuildConfig.APPLICATION_ID + ".ACTION_FIRED"
     const val ACTION_INEXACT_FIRED = BuildConfig.APPLICATION_ID + ".ACTION_INEXACT_FIRED"
     const val EXTRA_ID = "intent.extra.alarm"
-    const val EXTRA_TYPE = "intent.extra.type"
   }
 }

--- a/app/src/main/java/com/better/alarm/model/IAlarmsScheduler.java
+++ b/app/src/main/java/com/better/alarm/model/IAlarmsScheduler.java
@@ -19,7 +19,7 @@ import java.util.Calendar;
 
 public interface IAlarmsScheduler {
   /** remove all Calendars of the AlarmCore with given id */
-  public void removeAlarm(int id);
+  void removeAlarm(int id);
 
   /**
    * Set all from a map.

--- a/app/src/main/java/com/better/alarm/model/IAlarmsScheduler.java
+++ b/app/src/main/java/com/better/alarm/model/IAlarmsScheduler.java
@@ -26,7 +26,7 @@ public interface IAlarmsScheduler {
    *
    * @param id
    */
-  public void setAlarm(int id, CalendarType calendarType, Calendar calendar, AlarmValue alarmValue);
+  void setAlarm(int id, CalendarType calendarType, Calendar calendar, AlarmValue alarmValue);
 
   void setInexactAlarm(int id, Calendar calendar);
 

--- a/app/src/main/java/com/better/alarm/presenter/AlarmsListActivity.kt
+++ b/app/src/main/java/com/better/alarm/presenter/AlarmsListActivity.kt
@@ -192,7 +192,7 @@ class AlarmsListActivity : AppCompatActivity() {
         .subscribe { alarms -> checkPermissions(this, alarms.map { it.alarmtone }) }
         .apply {}
   }
-    private fun<V> collectionToString(col: Collection<V>, map: (V) -> String) : String {
+    public fun<V> collectionToString(col: Collection<V>, map: (V) -> String) : String {
         val b = StringBuilder()
         for ((i, v) in col.withIndex()) {
             b.append(
@@ -203,7 +203,7 @@ class AlarmsListActivity : AppCompatActivity() {
         }
         return b.toString()
     }
-    private fun<V> collectionToString(col: Collection<V>) : String {
+    public fun<V> collectionToString(col: Collection<V>) : String {
         return collectionToString(col, map = {v ->  v.toString()})
     }
   override fun onStart() {

--- a/app/src/main/java/com/better/alarm/presenter/AlarmsListActivity.kt
+++ b/app/src/main/java/com/better/alarm/presenter/AlarmsListActivity.kt
@@ -28,6 +28,7 @@ import android.transition.ChangeTransform
 import android.transition.Fade
 import android.transition.Slide
 import android.transition.TransitionSet
+import android.util.Log
 import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
@@ -51,6 +52,7 @@ import com.better.alarm.logger.Logger
 import com.better.alarm.lollipop
 import com.better.alarm.model.AlarmValue
 import com.better.alarm.model.AlarmsRepository
+import com.better.alarm.statemachine.StateMachine
 import com.better.alarm.util.Optional
 import com.better.alarm.util.formatToast
 import com.google.android.material.snackbar.Snackbar
@@ -82,7 +84,8 @@ class AlarmsListActivity : AppCompatActivity() {
   private val dynamicThemeHandler: DynamicThemeHandler by globalInject()
 
   companion object {
-    val uiStoreModule: Module = module { single<UiStore> { createStore(EditedAlarm(), get()) } }
+      private const val TAG = "AlarmsListActivity"
+      val uiStoreModule: Module = module { single<UiStore> { createStore(EditedAlarm(), get()) } }
 
     private fun createStore(edited: EditedAlarm, alarms: IAlarmsManager): UiStore {
       class UiStoreIR : UiStore {
@@ -189,7 +192,20 @@ class AlarmsListActivity : AppCompatActivity() {
         .subscribe { alarms -> checkPermissions(this, alarms.map { it.alarmtone }) }
         .apply {}
   }
-
+    private fun<V> collectionToString(col: Collection<V>, map: (V) -> String) : String {
+        val b = StringBuilder()
+        for ((i, v) in col.withIndex()) {
+            b.append(
+                " " +
+                    "\n Entry >>>>> No [$i]" +
+                    "\n    item = ${map(v)}"
+            )
+        }
+        return b.toString()
+    }
+    private fun<V> collectionToString(col: Collection<V>) : String {
+        return collectionToString(col, map = {v ->  v.toString()})
+    }
   override fun onStart() {
     super.onStart()
     configureTransactions()
@@ -202,6 +218,7 @@ class AlarmsListActivity : AppCompatActivity() {
             .sets()
             .withLatestFrom(store.uiVisible, { set, uiVisible -> set to uiVisible })
             .subscribe { (set: Store.AlarmSet, uiVisible: Boolean) ->
+                Log.println(Log.VERBOSE, TAG, "configureSnackbar: new alarmSet $set")
               if (uiVisible) {
                 showSnackbar(set)
               }
@@ -213,7 +230,7 @@ class AlarmsListActivity : AppCompatActivity() {
    * https://github.com/yuriykulikov/AlarmClock/issues/372
    */
   private fun showSnackbar(set: Store.AlarmSet) {
-    val toastText = formatToast(applicationContext, set.millis)
+    val toastText = formatToast(applicationContext, set.millis) + " FOUND THIS!!!"
     Snackbar.make(findViewById(R.id.main_fragment_container), toastText, Snackbar.LENGTH_LONG)
         .apply {
           val text = view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)

--- a/app/src/main/java/com/better/alarm/presenter/AlarmsListFragment.kt
+++ b/app/src/main/java/com/better/alarm/presenter/AlarmsListFragment.kt
@@ -6,6 +6,7 @@ import android.app.AlertDialog
 import android.content.Context
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.util.Log
 import android.view.ContextMenu
 import android.view.ContextMenu.ContextMenuInfo
 import android.view.LayoutInflater
@@ -71,7 +72,8 @@ class AlarmsListFragment : Fragment() {
   private var listRowLayout = prefs.layout()
 
   companion object {
-    var fabSync: Channel<Unit>? = null
+      private const val TAG = "AlarmsListFragment"
+      var fabSync: Channel<Unit>? = null
   }
   inner class AlarmListAdapter(alarmTime: Int, label: Int, private val values: List<AlarmValue>) :
       ArrayAdapter<AlarmValue>(requireContext(), alarmTime, label, values) {
@@ -115,8 +117,11 @@ class AlarmsListFragment : Fragment() {
           // onOff
           .setOnClickListener {
             val enable = !alarm.isEnabled
-            logger.debug { "onClick: ${if (enable) "enable" else "disable"}" }
-            alarms.getAlarm(alarm.id)?.enable(enable)
+//            logger.debug { "onClick: ${if (enable) "enable" else "disable"}" }
+            val currAlarm =  alarms.getAlarm(alarm.id)
+              Log.println(Log.INFO, TAG, "getView: alarm is: $currAlarm" +
+                  ",\n setting enabled = $enable")
+              currAlarm?.enable(enable)
           }
 
       val pickerClickTarget =
@@ -271,10 +276,10 @@ class AlarmsListFragment : Fragment() {
 
     lollipop { configureBottomDrawer(view) }
 
-    logger.trace { "onCreateView() { postponeEnterTransition() }" }
+//    logger.trace { "onCreateView() { postponeEnterTransition() }" }
     postponeEnterTransition()
     view.doOnPreDraw {
-      logger.trace { "onCreateView() { doOnPreDraw { startPostponedEnterTransition() } }" }
+//      logger.trace { "onCreateView() { doOnPreDraw { startPostponedEnterTransition() } }" }
       startPostponedEnterTransition()
     }
 

--- a/app/src/main/java/com/better/alarm/presenter/ToastPresenter.kt
+++ b/app/src/main/java/com/better/alarm/presenter/ToastPresenter.kt
@@ -18,11 +18,15 @@
 package com.better.alarm.presenter
 
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import com.better.alarm.configuration.Store
 import com.better.alarm.util.formatToast
 
 class ToastPresenter(private val store: Store, private val context: Context) {
+    companion object {
+        private const val TAG = "ToastPresenter"
+    }
   private var sToast: Toast? = null
 
   fun start() {
@@ -30,6 +34,7 @@ class ToastPresenter(private val store: Store, private val context: Context) {
         .sets()
         .withLatestFrom(store.uiVisible, { set, uiVisible -> set to uiVisible })
         .subscribe { (set: Store.AlarmSet, uiVisible: Boolean) ->
+            Log.println(Log.INFO, TAG, "start: ")
           if (!uiVisible && set.alarm.isEnabled) {
             popAlarmSetToast(context, set.millis)
           }
@@ -42,7 +47,7 @@ class ToastPresenter(private val store: Store, private val context: Context) {
   }
 
   private fun popAlarmSetToast(context: Context, timeInMillis: Long) {
-    val toastText = formatToast(context, timeInMillis)
+    val toastText = formatToast(context, timeInMillis) + "FOUND THIS!!!"
     val toast = Toast.makeText(context, toastText, Toast.LENGTH_LONG)
     setToast(toast)
     toast.show()

--- a/app/src/main/java/com/better/alarm/statemachine/StateMachine.kt
+++ b/app/src/main/java/com/better/alarm/statemachine/StateMachine.kt
@@ -23,6 +23,7 @@
  */
 package com.better.alarm.statemachine
 
+import android.util.Log
 import com.better.alarm.logger.Logger
 import kotlin.properties.Delegates
 
@@ -121,180 +122,222 @@ import kotlin.properties.Delegates
  * is inspired by an
  * [Android SM](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/com/android/internal/util/StateMachine.java)
  */
-internal class StateMachine<T : Any>(val name: String, private val logger: Logger) {
-  /** State hierarchy as a tree. Root Node is null. */
-  private lateinit var tree: Map<State<T>, Node<T>>
+internal class StateMachine<T : Any>(val name: String, private val logger: Logger)
+{
 
-  /** Current state of the state machine */
-  private var currentState: State<T> by Delegates.notNull()
-
-  /** State into which the state machine transitions */
-  private var targetState: State<T> by Delegates.notNull()
-
-  /**
-   * Counter which is incremented when SM starts processing and decremented when it finishes. Use to
-   * make sure that [transitionTo] is only used when SM is processing. See [withProcessingFlag].
-   */
-  private var processing: Int = 0
-
-  /** Events not processed by current state and put on hold until the next transition */
-  private val deferred = mutableListOf<T>()
-
-  /**
-   * Configure and start the state machine. [State.enter] will be called on the initial state and
-   * its parents.
-   */
-  fun start(event: T? = null, configurator: StateMachineBuilder.(StateMachineBuilder) -> Unit) {
-    tree = StateMachineBuilder().apply { configurator(this, this) }.mutableTree.toMap()
-    enterInitialState(event)
-  }
-
-  /** Process the event. If [State.onEvent] returns false, event goes to the next parent state. */
-  fun sendEvent(event: T) = withProcessingFlag {
-    val hierarchy = branchToRoot(currentState)
-
-    logger.debug { "[$name] event $event -> (${hierarchy.joinToString(" > ")})" }
-
-    val processedIn: State<T>? =
-        hierarchy.firstOrNull { state: State<T> ->
-          logger.trace { "[$name] $state.processEvent()" }
-          state.onEvent(event)
-        }
-
-    requireNotNull(processedIn) { "[$name] was not able to handle $event" }
-
-    performTransitions(event)
-  }
-
-  /**
-   * Trigger a transition. Allowed only while processing events. All exiting states will receive
-   * [State.exit] and all entering states [State.enter] calls. Transitions will be performed after
-   * the [sendEvent] is done. Can be called from [State.enter]. In this case last call wins.
-   */
-  fun transitionTo(state: State<T>) {
-    check(processing > 0) { "transitionTo can only be called within processEvent" }
-    targetState = state
-  }
-
-  /**
-   * Indicate that current state defers processing of this event to the next state. Event will be
-   * delivered upon state change to the next state.
-   */
-  fun deferEvent(event: T) {
-    logger.debug { "[$name] deferring $event from $name to next state" }
-    deferred.add(event)
-  }
-
-  /**
-   * Loop until [currentState] is not the same as [targetState] which can be caused by
-   * [transitionTo]
-   */
-  private fun performTransitions(reason: T?) {
-    check(processing > 0)
-    while (currentState != targetState) {
-      val currentBranch = branchToRoot(currentState)
-      val targetBranch = branchToRoot(targetState)
-      val common = currentBranch.intersect(targetBranch)
-
-      val toExit = currentBranch.minus(common)
-      val toEnter = targetBranch.minus(common).reversed()
-
-      // now that we know the branches, change the current state to target state
-      // calling exit/enter may change this afterwards
-      currentState = targetState
-
-      logger.debug { "[$name] transition $toExit => $toEnter" }
-
-      toExit.forEach { state -> state.exit(reason) }
-      toEnter.forEach { state -> state.enter(reason) }
-
-      processDeferred()
+    companion object {
+        private const val TAG = "StateMachine"
     }
-  }
+    /** State hierarchy as a tree. Root Node is null. */
+    private lateinit var tree: Map<State<T>, Node<T>>
 
-  private fun processDeferred() {
-    val copy = deferred.toList()
-    deferred.clear()
-    copy.forEach { sendEvent(it) }
-  }
+    /** Current state of the state machine */
+    var currentState: State<T> by Delegates.notNull()
+//  private var currentState: State<T> by Delegates.notNull()
 
-  private fun branchToRoot(state: State<T>): List<State<T>> {
-    return generateSequence(tree.getValue(state)) { it.parentNode }.map { it.state }.toList()
-  }
-
-  /** Goes all states from root to [currentState] and invokes [State.enter] */
-  private fun enterInitialState(event: T?) = withProcessingFlag {
-    val toEnter = branchToRoot(currentState).reversed()
-    logger.debug { "[$name] entering $toEnter" }
-    toEnter.forEach { it.enter(event) }
-    performTransitions(event)
-  }
-
-  /**
-   * Executes the [block] increasing [processing] before and decreasing it after the block
-   * execution.
-   */
-  private inline fun withProcessingFlag(block: () -> Unit) {
-    processing++
-    block()
-    processing--
-  }
-
-  inner class StateMachineBuilder {
-    internal val mutableTree = mutableMapOf<State<T>, Node<T>>()
+    /** State into which the state machine transitions */
+    public var targetState: State<T> by Delegates.notNull()
 
     /**
-     * Adds a new state. Parent must be added before it is used here as [parent].
-     *
-     * At least one state must have [initial] == true or [setInitialState]
+     * Counter which is incremented when SM starts processing and decremented when it finishes. Use to
+     * make sure that [transitionTo] is only used when SM is processing. See [withProcessingFlag].
      */
-    fun addState(state: State<T>, parent: State<T>? = null, initial: Boolean = false) {
-      val parentNode: Node<T>? =
-          parent?.let {
-            requireNotNull(mutableTree[it]) { "Parent $parent must be added before adding a child" }
-          }
+    private var processing: Int = 0
 
-      mutableTree[state] = Node(state, parentNode)
+    /** Events not processed by current state and put on hold until the next transition */
+    private val deferred = mutableListOf<T>()
 
-      if (initial) setInitialState(state)
+    /**
+     * Configure and start the state machine. [State.enter] will be called on the initial state and
+     * its parents.
+     */
+    fun start(event: T? = null, configurator: StateMachineBuilder.(StateMachineBuilder) -> Unit) {
+        tree = StateMachineBuilder().apply { configurator(this, this) }.mutableTree.toMap()
+        enterInitialState(event)
     }
 
-    fun setInitialState(state: State<T>) {
-      currentState = state
-      targetState = state
+    /** Process the event. If [State.onEvent] returns false, event goes to the next parent state. */
+    fun sendEvent(event: T) = withProcessingFlag {
+//      Log.println(Log.ERROR, TAG, " " +
+//          "\n sendEvent: event = $event" +
+//          ", \n stack = ${StringUtils.getSingleStackTrace()}" +
+//      ",\n current state = $currentState" +
+//      ",\n target state = $targetState"
+//      )
+        val hierarchy = branchToRoot(currentState)
+
+//    logger.debug { "[$name] event $event -> (${hierarchy.joinToString(" > ")})" }
+        Log.d(TAG, "sendEvent: branch = $hierarchy")
+        val processedIn: State<T>? =
+            hierarchy.firstOrNull { state: State<T> ->
+//          logger.trace { "[$name] $state.processEvent()" }
+//            Log.println(Log.INFO, TAG, "sendEvent: state = $state")
+                state.onEvent(event)
+            }
+
+        requireNotNull(processedIn) { "[$name] was not able to handle $event" }
+
+        performTransitions(event)
     }
-  }
+
+    /**
+     * Trigger a transition. Allowed only while processing events. All exiting states will receive
+     * [State.exit] and all entering states [State.enter] calls. Transitions will be performed after
+     * the [sendEvent] is done. Can be called from [State.enter]. In this case last call wins.
+     */
+    fun transitionTo(state: State<T>) {
+        check(processing > 0) { "transitionTo can only be called within processEvent" }
+        targetState = state
+    }
+
+    /**
+     * Indicate that current state defers processing of this event to the next state. Event will be
+     * delivered upon state change to the next state.
+     */
+    fun deferEvent(event: T) {
+        logger.debug { "[$name] deferring $event from $name to next state" }
+        deferred.add(event)
+    }
+
+    /**
+     * Loop until [currentState] is not the same as [targetState] which can be caused by
+     * [transitionTo]
+     */
+    private fun performTransitions(reason: T?) {
+        check(processing > 0)
+//      Log.d(TAG, "performTransitions: current = $currentState" +
+//          ",\n target = $targetState, \n stack = ${StringUtils.getSingleStackTrace()}")
+        while (currentState != targetState) {
+            val currentBranch = branchToRoot(currentState)
+//        Log.println(Log.VERBOSE, TAG, "performTransitions: currentBranch = $currentBranch")
+            val targetBranch = branchToRoot(targetState)
+//        Log.println(Log.INFO, TAG, "performTransitions: targetBranch = $targetBranch")
+            val common = currentBranch.intersect(targetBranch)
+
+            val toExit = currentBranch.minus(common)
+            val toEnter = targetBranch.minus(common).reversed()
+
+            // now that we know the branches, change the current state to target state
+            // calling exit/enter may change this afterwards
+            currentState = targetState
+
+            logger.debug { "[$name] transition $toExit => $toEnter" }
+
+            toExit.forEach { state ->
+//          Log.println(Log.WARN, TAG, "performTransitions: exiting... $state")
+                state.exit(reason) }
+            toEnter.forEach { state ->
+//          Log.println(Log.VERBOSE, TAG, "performTransitions: entering... $state")
+                state.enter(reason) }
+
+            processDeferred()
+        }
+    }
+
+    private fun processDeferred() {
+        val copy = deferred.toList()
+        deferred.clear()
+        copy.forEach {
+//        Log.println(Log.ASSERT, TAG, "processDeferred: processing event = $it")
+            sendEvent(it) }
+    }
+
+    private fun branchToRoot(state: State<T>): List<State<T>> {
+        return generateSequence(tree.getValue(state)) { it.parentNode }.map { it.state }.toList()
+    }
+
+    /** Goes all states from root to [currentState] and invokes [State.enter] */
+    private fun enterInitialState(event: T?) = withProcessingFlag {
+        val toEnter = branchToRoot(currentState).reversed()
+        logger.debug { "[$name] entering $toEnter" }
+        toEnter.forEach { it.enter(event) }
+        performTransitions(event)
+    }
+
+    /**
+     * Executes the [block] increasing [processing] before and decreasing it after the block
+     * execution.
+     */
+    private inline fun withProcessingFlag(block: () -> Unit) {
+        processing++
+        block()
+        processing--
+    }
+
+    inner class StateMachineBuilder {
+        internal val mutableTree = mutableMapOf<State<T>, Node<T>>()
+
+        /**
+         * Adds a new state. Parent must be added before it is used here as [parent].
+         *
+         * At least one state must have [initial] == true or [setInitialState]
+         */
+        fun addState(state: State<T>, parent: State<T>? = null, initial: Boolean = false) {
+            val parentNode: Node<T>? =
+                parent?.let {
+                    requireNotNull(mutableTree[it]) { "Parent $parent must be added before adding a child" }
+                }
+
+            mutableTree[state] = Node(state, parentNode)
+
+            if (initial) setInitialState(state)
+        }
+
+        fun setInitialState(state: State<T>) {
+            currentState = state
+            targetState = state
+        }
+    }
 }
 
 /** Node in the state tree */
-internal class Node<T>(var state: State<T>, var parentNode: Node<T>?)
+internal class Node<T>(var state: State<T>, var parentNode: Node<T>?) {
+    override fun toString(): String {
+        return "<START><><state = $state>" +
+            "\n    Parent = $parentNode" +
+            "\n <state = $state><><END>"
+    }
+}
+
+fun<K, V> mapToString(map: Map<K, V>) : String {
+    val b = StringBuilder()
+    for ((i, e: Map.Entry<K, V>) in map.entries.withIndex()) {
+        b.append(
+            " " +
+                "\n Entry >>>>> No [$i]" +
+                "\n    key = ${e.key}" +
+                "\n    value = ${e.value}"
+        )
+    }
+    return b.toString()
+}
 
 /** Event handler in a [StateMachine] */
 abstract class State<T> {
-  /**
-   * State is entered. It is not called if the state is re-entered (transition to self).
-   *
-   * [reason] is the message which caused and and *null* if [enter] is called from the initial state
-   * is entered.
-   */
-  abstract fun enter(reason: T?)
+    /**
+     * State is entered. It is not called if the state is re-entered (transition to self).
+     *
+     * [reason] is the message which caused and and *null* if [enter] is called from the initial state
+     * is entered.
+     */
+    abstract fun enter(reason: T?)
 
-  /**
-   * State is exited. It is only called if the state is completely left. Transitions in the child
-   * states do not cause this.
-   *
-   * [reason] is the message which caused and and *null* if [exit] is called from the initial state
-   * is entered.
-   */
-  abstract fun exit(reason: T?)
+    /**
+     * State is exited. It is only called if the state is completely left. Transitions in the child
+     * states do not cause this.
+     *
+     * [reason] is the message which caused and and *null* if [exit] is called from the initial state
+     * is entered.
+     */
+    abstract fun exit(reason: T?)
 
-  /**
-   * Process events in the state. Return *true* if the state has handled the event and *false* if
-   * not. Unhandled event will be propagated to the parent.
-   */
-  abstract fun onEvent(event: T): Boolean
+    /**
+     * Process events in the state. Return *true* if the state has handled the event and *false* if
+     * not. Unhandled event will be propagated to the parent.
+     */
+    abstract fun onEvent(event: T): Boolean
 
-  open val name: String = javaClass.simpleName
+    open val name: String = javaClass.simpleName
 
-  override fun toString(): String = name
+    override fun toString(): String = name
 }

--- a/app/src/main/java/com/better/alarm/statemachine/StateMachine.kt
+++ b/app/src/main/java/com/better/alarm/statemachine/StateMachine.kt
@@ -128,6 +128,11 @@ internal class StateMachine<T : Any>(val name: String, private val logger: Logge
     companion object {
         private const val TAG = "StateMachine"
     }
+
+    override fun toString(): String {
+        return super.toString() +
+            ",\n >> current state = $currentState <<"
+    }
     /** State hierarchy as a tree. Root Node is null. */
     private lateinit var tree: Map<State<T>, Node<T>>
 
@@ -171,7 +176,7 @@ internal class StateMachine<T : Any>(val name: String, private val logger: Logge
         val processedIn: State<T>? =
             hierarchy.firstOrNull { state: State<T> ->
 //          logger.trace { "[$name] $state.processEvent()" }
-//            Log.println(Log.INFO, TAG, "sendEvent: state = $state")
+            Log.println(Log.INFO, TAG, "sendEvent: state = $state")
                 state.onEvent(event)
             }
 

--- a/app/src/test/java/com/better/alarm/AlarmSchedulerTest.kt
+++ b/app/src/test/java/com/better/alarm/AlarmSchedulerTest.kt
@@ -59,7 +59,7 @@ class AlarmSchedulerTest {
     var calendar: Calendar? = null
     val inexactAlarms = mutableMapOf<Int, Calendar>()
 
-    override fun setUpRTCAlarm(id: Int, typeName: String, calendar: Calendar) {
+    override fun setUpRTCAlarm(id: Int, calendar: Calendar) {
       this.id = id
       this.typeName = typeName
       this.calendar = calendar
@@ -71,7 +71,7 @@ class AlarmSchedulerTest {
       calendar = null
     }
 
-    override fun fireNow(id: Int, typeName: String) {}
+    override fun fireNow(id: Int) {}
 
     override fun removeInexactAlarm(id: Int) {
       inexactAlarms.remove(id)


### PR DESCRIPTION
To fix [bug](https://github.com/yuriykulikov/AlarmClock/issues/533#issue-1614291889)

The changes are somewhat drastic on the given class AlarmScheduler.... and there is still a default interface that is currently passing id = 0. (ISetAlarmStrategy#setInexactAlarm(calendar: Calendar, pendingIntent: PendingIntent)).

I'm yet to understand what is that interface doing.

But for all other alarms it seems to be working fine on Oreo version.
I've deleted some logs so if you choose to merge this, beware of that.