### PR TITLE
add "forever option" to skip duration settings

### DIFF
--- a/app/src/main/java/com/better/alarm/domain/AlarmCore.kt
+++ b/app/src/main/java/com/better/alarm/domain/AlarmCore.kt
@@ -411,6 +411,9 @@ class AlarmCore(
           skipTime == -1 -> {
             // switched off
           }
+          skipTime == -2 -> {
+            broadcastAlarmState(Intents.ALARM_SHOW_SKIP)
+          }
           toShowSkip.after(calendars.now()) -> {
             mAlarmsScheduler.setInexactAlarm(id, toShowSkip)
           }

--- a/app/src/main/res/values-de/strings_skip.xml
+++ b/app/src/main/res/values-de/strings_skip.xml
@@ -4,6 +4,7 @@
     <string name="notification_alarm_is_about_to_go_off">Der Alarm geht gleich los</string>
     <string name="skip_duration_title">Wecker überspringen Benachrichtigung</string>
     <string-array name="skip_duration_entries">
+        <item>für immer</item>
         <item>Aus</item>
         <item>15 Minuten</item>
         <item>30 minuten</item>

--- a/app/src/main/res/values-es/strings_skip.xml
+++ b/app/src/main/res/values-es/strings_skip.xml
@@ -4,6 +4,7 @@
     <string name="notification_alarm_is_about_to_go_off">La alarma está a punto de sonar.</string>
     <string name="skip_duration_title">Notificación "Saltar alarma"</string>
     <string-array name="skip_duration_entries">
+        <item>Para Siempre</item>
         <item>Apagado</item>
         <item>15 minutos</item>
         <item>30 minutos</item>

--- a/app/src/main/res/values-it/strings_skip.xml
+++ b/app/src/main/res/values-it/strings_skip.xml
@@ -4,6 +4,7 @@
     <string name="notification_alarm_is_about_to_go_off">La sveglia sta per suonare</string>
     <string name="skip_duration_title">Notifica "Salta sveglia"</string>
     <string-array name="skip_duration_entries">
+        <item>Per Sempre</item>
         <item>Disattivato</item>
         <item>15 minuti</item>
         <item>30 minuti</item>

--- a/app/src/main/res/values-nb/strings_skip.xml
+++ b/app/src/main/res/values-nb/strings_skip.xml
@@ -4,6 +4,7 @@
     <string name="notification_alarm_is_about_to_go_off">Alarmen er i ferd med å gå</string>
     <string name="skip_duration_title">Hopp over alarmvarsel</string>
     <string-array name="skip_duration_entries">
+        <item>For Alltid</item>
         <item>Av</item>
         <item>15 minutter</item>
         <item>30 minutter</item>

--- a/app/src/main/res/values-ru/strings_skip.xml
+++ b/app/src/main/res/values-ru/strings_skip.xml
@@ -4,6 +4,7 @@
     <string name="notification_alarm_is_about_to_go_off">Будильник вот-вот сработает</string>
     <string name="skip_duration_title">Уведомление "Пропустить будильник"</string>
     <string-array name="skip_duration_entries">
+        <item>Навсегда</item>
         <item>Выкл.</item>
         <item>15 минут</item>
         <item>30 минут</item>

--- a/app/src/main/res/values-uk/strings_skip.xml
+++ b/app/src/main/res/values-uk/strings_skip.xml
@@ -4,6 +4,7 @@
     <string name="notification_alarm_is_about_to_go_off">Будильник от-от спрацює</string>
     <string name="skip_duration_title">Повідомлення "пропустити будильник"</string>
     <string-array name="skip_duration_entries">
+        <item>Назавжди</item>
         <item>Вимк.</item>
         <item>15 хвилин</item>
         <item>30 хвилин</item>

--- a/app/src/main/res/values-zh-rCN/strings_skip.xml
+++ b/app/src/main/res/values-zh-rCN/strings_skip.xml
@@ -4,19 +4,12 @@
     <string name="notification_alarm_is_about_to_go_off">闹钟快要响了</string>
     <string name="skip_duration_title">跳过闹钟通知</string>
     <string-array name="skip_duration_entries">
+        <item>永远</item>
         <item>关闭</item>
         <item>15 分钟</item>
         <item>30 分钟</item>
         <item>1 小时</item>
         <item>2 小时</item>
         <item>3 小时</item>
-    </string-array>
-    <string-array name="skip_duration_values">
-        <item>-1</item>
-        <item>15</item>
-        <item>30</item>
-        <item>60</item>
-        <item>120</item>
-        <item>180</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings_skip.xml
+++ b/app/src/main/res/values/strings_skip.xml
@@ -4,6 +4,7 @@
     <string name="notification_alarm_is_about_to_go_off">Alarm is about to go off on</string>
     <string name="skip_duration_title">Skip alarm notification</string>
     <string-array name="skip_duration_entries">
+        <item>Forever</item>
         <item>Off</item>
         <item>15 minutes</item>
         <item>30 minutes</item>
@@ -12,6 +13,7 @@
         <item>3 hours</item>
     </string-array>
     <string-array name="skip_duration_values">
+        <item>-2</item>
         <item>-1</item>
         <item>15</item>
         <item>30</item>


### PR DESCRIPTION
a minor change that allow users to skip alarm in any time before it fires.